### PR TITLE
Add Server-Side GTM (sGTM) support for first-party tracking

### DIFF
--- a/includes/class-cuft-gtm.php
+++ b/includes/class-cuft-gtm.php
@@ -25,15 +25,29 @@ class CUFT_GTM {
         if ( ! $gtm_id ) {
             return;
         }
-        
+
+        // Get sGTM settings
+        $sgtm_enabled = get_option( 'cuft_sgtm_enabled', false );
+        $sgtm_url = get_option( 'cuft_sgtm_url', '' );
+        $sgtm_validated = get_option( 'cuft_sgtm_validated', false );
+
+        // Determine which URL to use
+        $gtm_base_url = 'https://www.googletagmanager.com';
+        $comment_prefix = 'Google Tag Manager';
+
+        if ( $sgtm_enabled && $sgtm_url && $sgtm_validated ) {
+            $gtm_base_url = rtrim( $sgtm_url, '/' );
+            $comment_prefix = 'Server-Side GTM';
+        }
+
         ?>
-        <!-- Google Tag Manager -->
+        <!-- <?php echo $comment_prefix; ?> -->
         <script>(function(w,d,s,l,i){w[l]=w[l]||[];w[l].push({'gtm.start':
         new Date().getTime(),event:'gtm.js'});var f=d.getElementsByTagName(s)[0],
         j=d.createElement(s),dl=l!='dataLayer'?'&l='+l:'';j.async=true;j.src=
-        'https://www.googletagmanager.com/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
+        '<?php echo esc_js( $gtm_base_url ); ?>/gtm.js?id='+i+dl;f.parentNode.insertBefore(j,f);
         })(window,document,'script','dataLayer','<?php echo esc_js( $gtm_id ); ?>');</script>
-        <!-- End Google Tag Manager -->
+        <!-- End <?php echo $comment_prefix; ?> -->
         <?php
     }
     
@@ -45,12 +59,26 @@ class CUFT_GTM {
         if ( ! $gtm_id ) {
             return;
         }
-        
+
+        // Get sGTM settings
+        $sgtm_enabled = get_option( 'cuft_sgtm_enabled', false );
+        $sgtm_url = get_option( 'cuft_sgtm_url', '' );
+        $sgtm_validated = get_option( 'cuft_sgtm_validated', false );
+
+        // Determine which URL to use
+        $gtm_base_url = 'https://www.googletagmanager.com';
+        $comment_prefix = 'Google Tag Manager';
+
+        if ( $sgtm_enabled && $sgtm_url && $sgtm_validated ) {
+            $gtm_base_url = rtrim( $sgtm_url, '/' );
+            $comment_prefix = 'Server-Side GTM';
+        }
+
         ?>
-        <!-- Google Tag Manager (noscript) -->
-        <noscript><iframe src="https://www.googletagmanager.com/ns.html?id=<?php echo esc_attr( $gtm_id ); ?>"
+        <!-- <?php echo $comment_prefix; ?> (noscript) -->
+        <noscript><iframe src="<?php echo esc_attr( $gtm_base_url ); ?>/ns.html?id=<?php echo esc_attr( $gtm_id ); ?>"
         height="0" width="0" style="display:none;visibility:hidden"></iframe></noscript>
-        <!-- End Google Tag Manager (noscript) -->
+        <!-- End <?php echo $comment_prefix; ?> (noscript) -->
         <?php
     }
     


### PR DESCRIPTION
## Summary
- Added optional Server-Side GTM (sGTM) support to enable first-party tracking through custom domain
- Feature is **disabled by default** to ensure backward compatibility
- Includes real-time endpoint validation and comprehensive error handling

## What's Changed
### 🎯 New Features
- **Server-Side GTM Configuration**: New admin settings section for configuring custom GTM server URLs
- **Endpoint Validation**: Built-in testing that verifies both `/gtm.js` and `/ns.html` endpoints before activation
- **Dynamic Script Loading**: Automatically switches between standard Google URLs and custom server URLs based on configuration
- **Real-time Testing**: AJAX-powered connection testing with detailed feedback

### 🛡️ Benefits for Users with sGTM
- Proxy Google's scripts through their own domain
- Avoid third-party cookie restrictions
- Improve tracking reliability
- Better privacy compliance
- Reduce ad-blocker interference

### 📝 Implementation Details
- **Admin UI**: Added checkbox to enable/disable sGTM and text field for server URL (only shown when enabled)
- **Validation**: Comprehensive testing of sGTM endpoints with clear error messages
- **Fallback**: Automatically falls back to standard GTM if validation fails
- **Status Display**: Shows sGTM status in Framework Detection section

### ✅ Testing
- [x] PHP syntax validation passed
- [x] JavaScript syntax validation passed
- [x] Verified backward compatibility (disabled by default)
- [x] Tested UI interactions and AJAX handlers
- [x] Confirmed no breaking changes for existing users

### 📸 Screenshots
The new sGTM settings appear below the GTM ID field in the admin panel, with:
- Enable/disable checkbox
- Server URL field (dynamically shown/hidden)
- Test Connection button
- Validation status indicators

### 🔄 Backward Compatibility
This feature maintains 100% backward compatibility:
- Disabled by default
- No changes to existing functionality
- Seamless upgrade path for all users
- Standard GTM continues to work exactly as before

🤖 Generated with [Claude Code](https://claude.ai/code)