### PR TITLE
Version 3.9.1 - Fix test form asset loading and tracking display sync

### DIFF
--- a/assets/test-forms/cuft-test-avada.js
+++ b/assets/test-forms/cuft-test-avada.js
@@ -31,6 +31,11 @@
             // Add testing controls
             common.addTestingControls(formElement, 'avada');
 
+            // Update tracking info display with actual stored values
+            setTimeout(() => {
+                common.updateTrackingInfoDisplay('avada', formElement);
+            }, 100);
+
             common.log('Avada test form initialized');
         },
 
@@ -80,6 +85,10 @@
 
             // Prepare tracking data
             const formId = formElement.dataset.formId || 'fusion_form_1';
+
+            // Update sessionStorage with test tracking data BEFORE getting tracking data
+            common.updateTrackingDataForTest('avada', formId);
+
             const trackingData = common.getTestTrackingData('avada', formId);
 
             // Add form field values

--- a/assets/test-forms/cuft-test-cf7.js
+++ b/assets/test-forms/cuft-test-cf7.js
@@ -31,6 +31,11 @@
             // Add testing controls
             common.addTestingControls(formElement, 'contact_form_7');
 
+            // Update tracking info display with actual stored values
+            setTimeout(() => {
+                common.updateTrackingInfoDisplay('contact_form_7', formElement);
+            }, 100);
+
             common.log('CF7 test form initialized');
         },
 
@@ -80,6 +85,10 @@
 
             // Prepare tracking data
             const formId = formElement.dataset.formId || 'wpcf7-f123-p456-o1';
+
+            // Update sessionStorage with test tracking data BEFORE getting tracking data
+            common.updateTrackingDataForTest('contact_form_7', formId);
+
             const trackingData = common.getTestTrackingData('contact_form_7', formId);
 
             // Add form field values

--- a/assets/test-forms/cuft-test-elementor.js
+++ b/assets/test-forms/cuft-test-elementor.js
@@ -30,6 +30,11 @@
             // Add testing controls
             common.addTestingControls(formElement, 'elementor');
 
+            // Update tracking info display with actual stored values
+            setTimeout(() => {
+                common.updateTrackingInfoDisplay('elementor', formElement);
+            }, 100);
+
             common.log('Elementor test form initialized');
         },
 
@@ -78,6 +83,10 @@
 
             // Prepare tracking data
             const formId = formElement.dataset.formId || 'elementor-form-widget-test';
+
+            // Update sessionStorage with test tracking data BEFORE getting tracking data
+            common.updateTrackingDataForTest('elementor', formId);
+
             const trackingData = common.getTestTrackingData('elementor', formId);
 
             // Add form field values

--- a/assets/test-forms/cuft-test-gravity.js
+++ b/assets/test-forms/cuft-test-gravity.js
@@ -31,6 +31,11 @@
             // Add testing controls
             common.addTestingControls(formElement, 'gravity_forms');
 
+            // Update tracking info display with actual stored values
+            setTimeout(() => {
+                common.updateTrackingInfoDisplay('gravity_forms', formElement);
+            }, 100);
+
             common.log('Gravity Forms test form initialized');
         },
 
@@ -80,6 +85,10 @@
 
             // Prepare tracking data
             const formId = formElement.dataset.formId || 'gform_1';
+
+            // Update sessionStorage with test tracking data BEFORE getting tracking data
+            common.updateTrackingDataForTest('gravity_forms', formId);
+
             const trackingData = common.getTestTrackingData('gravity_forms', formId);
 
             // Add form field values

--- a/assets/test-forms/cuft-test-ninja.js
+++ b/assets/test-forms/cuft-test-ninja.js
@@ -31,6 +31,11 @@
             // Add testing controls
             common.addTestingControls(formElement, 'ninja_forms');
 
+            // Update tracking info display with actual stored values
+            setTimeout(() => {
+                common.updateTrackingInfoDisplay('ninja_forms', formElement);
+            }, 100);
+
             common.log('Ninja Forms test form initialized');
         },
 
@@ -80,6 +85,10 @@
 
             // Prepare tracking data
             const formId = formElement.dataset.formId || 'nf-form-3';
+
+            // Update sessionStorage with test tracking data BEFORE getting tracking data
+            common.updateTrackingDataForTest('ninja_forms', formId);
+
             const trackingData = common.getTestTrackingData('ninja_forms', formId);
 
             // Add form field values

--- a/choice-universal-form-tracker.php
+++ b/choice-universal-form-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Choice Universal Form Tracker
  * Description:       Universal form tracking for WordPress - supports Avada, Elementor Pro, Contact Form 7, Ninja Forms, Gravity Forms, and more. Tracks submissions and link clicks via Google Tag Manager's dataLayer.
- * Version:           3.9.0
+ * Version:           3.9.1
  * Author:            Choice OMG
  * Author URI:        https://choice.marketing
  * Text Domain:       choice-universal-form-tracker
@@ -14,8 +14,8 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants
-define( 'CUFT_VERSION', '3.9.0' );
-define( 'CUFT_URL', plugins_url( '', __FILE__ ) );
+define( 'CUFT_VERSION', '3.9.1' );
+define( 'CUFT_URL', plugins_url( '', __FILE__ ) . '/' );
 define( 'CUFT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CUFT_BASENAME', plugin_basename( __FILE__ ) );
 


### PR DESCRIPTION
## Summary
- Fixed CUFT_URL constant missing trailing slash causing 404 errors on test form assets
- Added tracking display sync to show actual stored values instead of hardcoded ones
- Updated sessionStorage before test form submissions to ensure consistency
- Applied fixes to all test frameworks (Avada, Elementor, CF7, Gravity, Ninja)

## Issues Resolved
- ❌ **404 errors**: `/wp-content/plugins/choice-uftassets/test-forms/...` → ✅ `/wp-content/plugins/choice-uft/assets/test-forms/...`
- ❌ **Display mismatch**: Hardcoded `test_click_avada_[timestamp]` → ✅ Actual stored values like `wbraid: test_wbraid`
- ❌ **Data inconsistency**: Display values ≠ submitted values → ✅ Display values = submitted values

## Test Plan
- [x] Verify all test form assets load without 404 errors
- [x] Confirm displayed tracking values match submitted values to Tag Manager
- [x] Test that form submissions continue working correctly
- [x] Validate syntax of all modified JavaScript and PHP files

🤖 Generated with [Claude Code](https://claude.ai/code)