### PR TITLE
Fix duplicate Avada events and standardize parameter naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,8 +209,8 @@ add_filter( 'cuft_debug', '__return_true' );
 {
   event: 'form_submit',
   formType: 'contact_form_7',        // Framework identifier
-  formId: 'contact-form-1',
-  formName: 'Contact Form',
+  form_id: 'contact-form-1',
+  form_name: 'Contact Form',
   user_email: 'user@example.com',
   user_phone: '1234567890',
 
@@ -314,8 +314,8 @@ add_filter( 'cuft_debug', '__return_true' );
 
   // Form Context
   formType: 'contact_form_7',
-  formId: 'contact-form-1',
-  formName: 'Contact Form',
+  form_id: 'contact-form-1',
+  form_name: 'Contact Form',
 
   // UTM Campaign Attribution (required for lead generation)
   utm_source: 'google',

--- a/assets/forms/cuft-avada-forms.js
+++ b/assets/forms/cuft-avada-forms.js
@@ -314,8 +314,8 @@
     var payload = {
       event: "form_submit",
       formType: "avada",
-      formId: form.getAttribute("id") || null,
-      formName:
+      form_id: form.getAttribute("id") || null,
+      form_name:
         form.getAttribute("name") ||
         form.getAttribute("data-form-name") ||
         null,
@@ -448,8 +448,8 @@
 
       log("Avada form submit detected! Starting tracking process...");
 
-      if (form.hasAttribute("data-cuft-observing")) return;
-      form.setAttribute("data-cuft-observing", "true");
+      if (form.hasAttribute("data-cuft-tracking")) return;
+      form.setAttribute("data-cuft-tracking", "true");
 
       var email = getFieldValue(form, "email");
       var phone = getFieldValue(form, "phone");
@@ -473,7 +473,7 @@
 
     for (var i = 0; i < fusionForms.length; i++) {
       var form = fusionForms[i];
-      if (form.hasAttribute("data-cuft-ajax-watching")) continue;
+      if (form.hasAttribute("data-cuft-tracking")) continue;
 
       // Check if form has email field (indicates it's a contact/lead form)
       var hasEmailField = findField(form, "email") !== null;
@@ -489,7 +489,7 @@
         continue;
       }
 
-      form.setAttribute("data-cuft-ajax-watching", "true");
+      form.setAttribute("data-cuft-tracking", "true");
       log("Setting up AJAX watcher for form with email field:", form.className);
 
       // Watch for form submissions via click events on submit buttons

--- a/assets/forms/cuft-cf7-forms.js
+++ b/assets/forms/cuft-cf7-forms.js
@@ -139,8 +139,8 @@
     var payload = {
       event: "form_submit",
       formType: "contact_form_7",
-      formId: formId,
-      formName: null, // CF7 doesn't typically expose form names in frontend
+      form_id: formId,
+      form_name: null, // CF7 doesn't typically expose form names in frontend
       submittedAt: new Date().toISOString(),
       cuft_tracked: true,
       cuft_source: "contact_form_7",

--- a/assets/forms/cuft-elementor-forms.js
+++ b/assets/forms/cuft-elementor-forms.js
@@ -397,8 +397,8 @@
     // Log debugging info about form identification
     log("Form identification debug:", {
       formElement: form,
-      formId: formId,
-      formName: formName,
+      form_id: formId,
+      form_name: formName,
       dataFormId: form.getAttribute("data-form-id"),
       id: form.getAttribute("id"),
       name: form.getAttribute("name"),
@@ -408,8 +408,8 @@
     var payload = {
       event: "form_submit",
       formType: "elementor",
-      formId: formId,
-      formName: formName,
+      form_id: formId,
+      form_name: formName,
       submittedAt: new Date().toISOString(),
       cuft_tracked: true,
       cuft_source: "elementor_pro",
@@ -663,8 +663,8 @@
     var payload = {
       event: "form_submit",
       formType: "elementor",
-      formId: trackingData.form_id || null,
-      formName: trackingData.form_name || null,
+      form_id: trackingData.form_id || null,
+      form_name: trackingData.form_name || null,
       submittedAt: trackingData.timestamp || new Date().toISOString(),
       cuft_tracked: true,
       cuft_source: trackingData.source || "elementor_pro_native"

--- a/assets/forms/cuft-gravity-forms.js
+++ b/assets/forms/cuft-gravity-forms.js
@@ -134,8 +134,8 @@
     var payload = {
       event: "form_submit",
       formType: "gravity_forms",
-      formId: formId,
-      formName: null, // GF doesn't typically expose form names in frontend
+      form_id: formId,
+      form_name: null, // GF doesn't typically expose form names in frontend
       submittedAt: new Date().toISOString(),
       cuft_tracked: true,
       cuft_source: "gravity_forms",

--- a/assets/forms/cuft-ninja-forms.js
+++ b/assets/forms/cuft-ninja-forms.js
@@ -218,8 +218,8 @@
     var payload = {
       event: "form_submit",
       formType: "ninja_forms",
-      formId: formId,
-      formName: null, // Ninja Forms doesn't typically expose form names in frontend
+      form_id: formId,
+      form_name: null, // Ninja Forms doesn't typically expose form names in frontend
       submittedAt: new Date().toISOString(),
       cuft_tracked: true,
       cuft_source: "ninja_forms",

--- a/assets/test-forms/cuft-test-avada.js
+++ b/assets/test-forms/cuft-test-avada.js
@@ -149,7 +149,7 @@
             const fusionSuccessEvent = new CustomEvent('fusion_form_success', {
                 detail: {
                     form: formElement,
-                    formId: trackingData.form_id,
+                    form_id: trackingData.form_id,
                     success: true,
                     data: {
                         email: trackingData.user_email,
@@ -166,7 +166,7 @@
             if (window.jQuery) {
                 window.jQuery(document).trigger('fusion_form_success', [{
                     form: formElement,
-                    formId: trackingData.form_id,
+                    form_id: trackingData.form_id,
                     success: true
                 }]);
                 common.log('✅ jQuery fusion_form_success event fired');
@@ -176,7 +176,7 @@
             setTimeout(() => {
                 const fusionSubmitEvent = new CustomEvent('fusion_form_submitted', {
                     detail: {
-                        formId: trackingData.form_id,
+                        form_id: trackingData.form_id,
                         response: 'success'
                     },
                     bubbles: true

--- a/assets/test-forms/cuft-test-elementor.js
+++ b/assets/test-forms/cuft-test-elementor.js
@@ -171,7 +171,7 @@
             const elementorFormEvent = new CustomEvent('elementor/frontend/form_success', {
                 detail: {
                     form: formElement,
-                    formId: trackingData.form_id,
+                    form_id: trackingData.form_id,
                     success: true
                 },
                 bubbles: true

--- a/assets/test-forms/cuft-test-gravity.js
+++ b/assets/test-forms/cuft-test-gravity.js
@@ -156,7 +156,7 @@
             // Fire page submit event
             const gformSubmitEvent = new CustomEvent('gform_page_loaded', {
                 detail: {
-                    formId: parseInt(formId),
+                    form_id: parseInt(formId),
                     currentPage: 1
                 },
                 bubbles: true

--- a/assets/test-forms/cuft-test-ninja.js
+++ b/assets/test-forms/cuft-test-ninja.js
@@ -165,7 +165,7 @@
             const ninjaSuccessEvent = new CustomEvent('nf_form_success', {
                 detail: {
                     form: formElement,
-                    formId: parseInt(formId),
+                    form_id: parseInt(formId),
                     response: {
                         success: true,
                         data: {

--- a/docs/ELEMENTOR_TRACKING.md
+++ b/docs/ELEMENTOR_TRACKING.md
@@ -58,8 +58,8 @@ Fired on every successful form submission.
 {
   event: "form_submit",
   formType: "elementor",
-  formId: "contact-form-1",
-  formName: "Contact Form",
+  form_id: "contact-form-1",
+  form_name: "Contact Form",
   submittedAt: "2025-01-22T10:30:00.000Z",
 
   // User Data (if available)


### PR DESCRIPTION
## Summary
- Fix duplicate form_submit events in Avada forms by standardizing tracking attributes
- Standardize parameter naming from camelCase (formId, formName) to snake_case (form_id, form_name) 
- Update documentation examples for consistency

## Changes Made
- **Avada Forms**: Fixed duplicate events by standardizing `data-cuft-tracking` attribute usage
- **Parameter Naming**: Changed all form tracking files to use `form_id` and `form_name` instead of `formId` and `formName`
- **Documentation**: Updated README.md and ELEMENTOR_TRACKING.md examples
- **Test Files**: Updated all test form files to maintain consistency

## Files Modified
- `assets/forms/cuft-avada-forms.js` - Fixed duplicate tracking attributes
- `assets/forms/cuft-elementor-forms.js` - Standardized parameter names
- `assets/forms/cuft-cf7-forms.js` - Standardized parameter names  
- `assets/forms/cuft-ninja-forms.js` - Standardized parameter names
- `assets/forms/cuft-gravity-forms.js` - Standardized parameter names
- `assets/test-forms/*.js` - Updated for consistency
- `README.md` - Updated examples
- `docs/ELEMENTOR_TRACKING.md` - Updated examples

## Test Plan
- [x] Verified no duplicate form_submit events from Avada forms
- [x] Confirmed consistent snake_case parameter naming across all frameworks
- [x] Updated documentation reflects new parameter names

🤖 Generated with [Claude Code](https://claude.ai/code)