### PR TITLE
Fix plugin deactivation during updates

### DIFF
--- a/assets/test-forms/cuft-test-common.js
+++ b/assets/test-forms/cuft-test-common.js
@@ -25,6 +25,8 @@
                 test_submission: true,
                 timestamp: new Date().toISOString(),
                 submittedAt: new Date().toISOString(),
+                cuft_tracked: true,
+                cuft_source: `${framework}_test`,
 
                 // Click IDs (all test forms will have these)
                 click_id: `test_click_${framework}_${timestamp}`,
@@ -130,7 +132,9 @@
                 click_id: formData.click_id || formData.gclid || formData.fbclid || '',
                 utm_campaign: formData.utm_campaign || '',
                 test_submission: true,
-                timestamp: new Date().toISOString()
+                timestamp: new Date().toISOString(),
+                cuft_tracked: true,
+                cuft_source: `${framework}_test_lead`
             };
 
             if (window.dataLayer) {

--- a/includes/class-cuft-admin.php
+++ b/includes/class-cuft-admin.php
@@ -780,7 +780,6 @@ class CUFT_Admin {
                 $result = $upgrader->upgrade( CUFT_BASENAME, array(
                     'package' => $download_url,
                     'destination' => WP_PLUGIN_DIR,
-                    'clear_destination' => true,
                     'clear_working' => true,
                     'hook_extra' => array(
                         'plugin' => CUFT_BASENAME,


### PR DESCRIPTION
## Summary
- Fix plugin deactivation issue during updates by removing `clear_destination` parameter
- Add missing `cuft_tracked` and `cuft_source` parameters to test form events

## Changes Made
### Plugin Update Fix
- Removed `clear_destination => true` from plugin upgrade process in `class-cuft-admin.php`
- This prevents WordPress from deactivating the plugin during updates
- Kept `clear_destination` for reinstalls since they explicitly reactivate afterward

### Test Form Consistency  
- Added `cuft_tracked: true` and `cuft_source` parameters to test form events
- Ensures test forms emit the same event structure as production tracking

## Test plan
- [x] Verify plugin stays active during updates
- [x] Test form events now include missing parameters
- [x] Reinstall functionality still works with reactivation

🤖 Generated with [Claude Code](https://claude.ai/code)