### PR TITLE
feat: GA4 event naming alignment and lead lifecycle (v3.22.0)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,32 @@ All notable changes to Choice Universal Form Tracker will be documented in this 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [3.22.0] - 2026-04-02
+
+### Added
+- **GA4 event naming alignment** — adopted GA4 recommended lead generation event names
+  - New `qualify_lead` event replaces strict `generate_lead` (email + phone + click_id)
+  - New broad `generate_lead` fires on any form submission with a valid email
+  - Full lifecycle events: `disqualify_lead`, `working_lead`, `close_convert_lead`, `close_unconvert_lead`
+- **Webhook `status` parameter** — send `?status=qualify_lead` (etc.) to record lifecycle events
+  - Backward compatible: `qualified=1` still works, mapped to `qualify_lead`
+- **GA4 Measurement Protocol** — server-side events fire at webhook time
+  - Configurable in Settings: GA4 Measurement ID and API Secret
+  - Graceful fallback when not configured
+- **Client-side event replay** — webhook events pushed to dataLayer on next pageview
+  - Cookie-based (no PHP sessions), fires once per event
+  - `cuft_replayed: true` flag for GTM trigger differentiation
+- **Admin settings for secrets** — Registration Secret, GA4 Measurement ID, and API Secret configurable from wp-admin
+  - `wp-config.php` constants still override DB values
+- **`ga_client_id` capture** — extracted from `_ga` cookie at form submission for Measurement Protocol
+
+### Changed
+- `generate_lead` now fires on any form with a valid email (previously required email + phone + click_id)
+- `status_qualified` webhook event renamed to `qualify_lead`
+
+### Deprecated
+- `generate_lead` with strict criteria (email + phone + click_id) — fires with `cuft_deprecated: true` for one version, then removed. Migrate GTM triggers to `qualify_lead`.
+
 ## [3.21.10] - 2026-03-20
 
 ### Fixed

--- a/assets/admin/cuft-event-validator.js
+++ b/assets/admin/cuft-event-validator.js
@@ -19,6 +19,7 @@
             this.requiredFields = {
                 'form_submit': ['event', 'cuft_tracked', 'cuft_source', 'form_type', 'form_id'],
                 'generate_lead': ['event', 'cuft_tracked', 'cuft_source', 'currency', 'value'],
+                'qualify_lead': ['event', 'cuft_tracked', 'cuft_source', 'currency', 'value'],
                 'phone_click': ['event', 'cuft_tracked', 'cuft_source', 'phone_number'],
                 'email_click': ['event', 'cuft_tracked', 'cuft_source', 'email_address']
             };

--- a/assets/cuft-click-integration.js
+++ b/assets/cuft-click-integration.js
@@ -159,6 +159,11 @@
         return;
       }
 
+      var nonce = (window.cuftConfig && window.cuftConfig.nonce) || "";
+      if (!nonce) {
+        return;
+      }
+
       var ajaxUrl =
         (window.cuftAjax && window.cuftAjax.ajax_url) ||
         (window.cuftConfig && window.cuftConfig.ajaxUrl) ||
@@ -169,7 +174,9 @@
         "GET",
         ajaxUrl +
           "?action=cuft_get_pending_events&click_id=" +
-          encodeURIComponent(clickId),
+          encodeURIComponent(clickId) +
+          "&nonce=" +
+          encodeURIComponent(nonce),
         true
       );
       xhr.onreadystatechange = function () {

--- a/assets/cuft-click-integration.js
+++ b/assets/cuft-click-integration.js
@@ -143,6 +143,65 @@
     // Add click ID to dataLayer
     addClickIdToDataLayer();
 
+    // Check for pending webhook events to replay into dataLayer
+    (function checkPendingEvents() {
+      var clickId = null;
+      try {
+        var match = document.cookie.match(/(^|; )cuft_click_id=([^;]*)/);
+        if (match && match[2]) {
+          clickId = decodeURIComponent(match[2]);
+        }
+      } catch (e) {
+        return;
+      }
+
+      if (!clickId) {
+        return;
+      }
+
+      var ajaxUrl =
+        (window.cuftAjax && window.cuftAjax.ajax_url) ||
+        (window.cuftConfig && window.cuftConfig.ajaxUrl) ||
+        "/wp-admin/admin-ajax.php";
+
+      var xhr = new XMLHttpRequest();
+      xhr.open(
+        "GET",
+        ajaxUrl +
+          "?action=cuft_get_pending_events&click_id=" +
+          encodeURIComponent(clickId),
+        true
+      );
+      xhr.onreadystatechange = function () {
+        if (xhr.readyState !== 4 || xhr.status !== 200) return;
+        try {
+          var resp = JSON.parse(xhr.responseText);
+          if (
+            resp.success &&
+            resp.data &&
+            resp.data.events &&
+            resp.data.events.length
+          ) {
+            var dl = (window.dataLayer = window.dataLayer || []);
+            for (var i = 0; i < resp.data.events.length; i++) {
+              var evt = resp.data.events[i];
+              dl.push({
+                event: evt.event,
+                click_id: clickId,
+                cuft_tracked: true,
+                cuft_source: "webhook_replay",
+                cuft_replayed: true,
+              });
+              log("Replayed webhook event:", evt.event);
+            }
+          }
+        } catch (e) {
+          // Silently fail on parse errors
+        }
+      };
+      xhr.send();
+    })();
+
     // Enhance existing forms
     enhanceFormSubmissions();
 

--- a/assets/cuft-dataLayer-utils.js
+++ b/assets/cuft-dataLayer-utils.js
@@ -158,7 +158,10 @@ window.cuftDataLayerUtils = (function () {
       if (cookie && cookie[2]) {
         var parts = cookie[2].split(".");
         if (parts.length >= 4) {
-          return parts[2] + "." + parts[3];
+          var clientId = parts[2] + "." + parts[3];
+          if (/^\d+\.\d+$/.test(clientId)) {
+            return clientId;
+          }
         }
       }
     } catch (e) {
@@ -491,6 +494,11 @@ window.cuftDataLayerUtils = (function () {
           framework: framework
         });
 
+        // Record generate_lead event to click tracking database
+        if (clickId) {
+          recordEvent(clickId, 'generate_lead', options.debug, formSubmitPayload.ga_client_id);
+        }
+
         if (options.debug && window.console && window.console.log) {
           window.console.log('[CUFT DataLayer] generate_lead event fired for:', framework);
         }
@@ -525,8 +533,8 @@ window.cuftDataLayerUtils = (function () {
           framework: framework
         });
 
-        if (options.console_logging === "yes" || (options.debug && window.console)) {
-          console.warn('[CUFT] "generate_lead" with strict criteria is deprecated. Update your GTM trigger to use "qualify_lead" instead.');
+        if ((options.console_logging === "yes" || options.debug) && window.console && window.console.warn) {
+          window.console.warn('[CUFT] "generate_lead" with strict criteria is deprecated. Update your GTM trigger to use "qualify_lead" instead.');
         }
 
         if (options.debug && window.console && window.console.log) {

--- a/assets/cuft-dataLayer-utils.js
+++ b/assets/cuft-dataLayer-utils.js
@@ -105,9 +105,9 @@ window.cuftDataLayerUtils = (function () {
   }
 
   /**
-   * Check if lead conditions are met (email + phone + click_id)
+   * Check if qualify_lead conditions are met (email + phone + click_id)
    */
-  function meetsLeadConditions(payload) {
+  function meetsQualifyConditions(payload) {
     // Must have valid email and phone
     if (!payload.user_email || !payload.user_phone) {
       return false;
@@ -120,6 +120,13 @@ window.cuftDataLayerUtils = (function () {
       }
     }
     return false;
+  }
+
+  /**
+   * Check if generate_lead conditions are met (broad: just email)
+   */
+  function meetsGenerateLeadConditions(payload) {
+    return !!payload.user_email;
   }
 
   /**
@@ -225,9 +232,9 @@ window.cuftDataLayerUtils = (function () {
   }
 
   /**
-   * Create standardized generate_lead event payload
+   * Create standardized qualify_lead event payload (strict: email + phone + click_id)
    */
-  function createGenerateLeadPayload(formSubmitPayload, framework, options) {
+  function createQualifyLeadPayload(formSubmitPayload, framework, options) {
     // Validate framework
     var frameworkConfig = FRAMEWORK_IDENTIFIERS[framework];
     if (!frameworkConfig) {
@@ -245,11 +252,33 @@ window.cuftDataLayerUtils = (function () {
     }
 
     // Override event-specific fields
-    leadPayload.event = "generate_lead";
+    leadPayload.event = "qualify_lead";
     leadPayload.cuft_source = frameworkConfig.cuft_source_lead;
     leadPayload.currency = options.lead_currency || "CAD";
     leadPayload.value = parseFloat(options.lead_value) || 100;
 
+    return leadPayload;
+  }
+
+  /**
+   * Create standardized generate_lead event payload (broad: just email)
+   */
+  function createGenerateLeadPayload(formSubmitPayload, framework, options) {
+    var frameworkConfig = FRAMEWORK_IDENTIFIERS[framework];
+    if (!frameworkConfig) {
+      throw new Error('[CUFT DataLayer] Unknown framework: ' + framework);
+    }
+    options = options || {};
+    var leadPayload = {};
+    for (var key in formSubmitPayload) {
+      if (formSubmitPayload.hasOwnProperty(key)) {
+        leadPayload[key] = formSubmitPayload[key];
+      }
+    }
+    leadPayload.event = "generate_lead";
+    leadPayload.cuft_source = frameworkConfig.cuft_source_lead;
+    leadPayload.currency = options.lead_currency || "CAD";
+    leadPayload.value = parseFloat(options.lead_value) || 100;
     return leadPayload;
   }
 
@@ -416,50 +445,57 @@ window.cuftDataLayerUtils = (function () {
         recordEvent(clickId, 'form_submit', options.debug);
       }
 
-      // Check for generate_lead conditions
-      var meetsConditions = meetsLeadConditions(formSubmitPayload);
-
-      if (options.debug && window.console && window.console.log) {
-        window.console.log('[CUFT DataLayer] Generate lead conditions check:', {
-          framework: framework,
-          meetsConditions: meetsConditions,
-          hasEmail: !!formSubmitPayload.user_email,
-          hasPhone: !!formSubmitPayload.user_phone,
-          hasClickId: !!(formSubmitPayload.click_id || formSubmitPayload.gclid ||
-                       formSubmitPayload.fbclid || formSubmitPayload.wbraid ||
-                       formSubmitPayload.gbraid || formSubmitPayload.msclkid),
-          clickIds: {
-            click_id: formSubmitPayload.click_id || null,
-            gclid: formSubmitPayload.gclid || null,
-            fbclid: formSubmitPayload.fbclid || null,
-            wbraid: formSubmitPayload.wbraid || null,
-            gbraid: formSubmitPayload.gbraid || null,
-            msclkid: formSubmitPayload.msclkid || null
-          }
-        });
-      }
-
-      if (meetsConditions) {
-        var leadPayload = createGenerateLeadPayload(formSubmitPayload, framework, {
+      // Fire generate_lead if email is present (broad GA4 meaning)
+      if (meetsGenerateLeadConditions(formSubmitPayload)) {
+        var generateLeadPayload = createGenerateLeadPayload(formSubmitPayload, framework, {
           lead_currency: options.lead_currency,
           lead_value: options.lead_value
         });
-        pushToDataLayer(leadPayload, {
+        pushToDataLayer(generateLeadPayload, {
           debug: options.debug,
           framework: framework
         });
 
-        // Record generate_lead event to click tracking database (fire-and-forget)
+        if (options.debug && window.console && window.console.log) {
+          window.console.log('[CUFT DataLayer] generate_lead event fired for:', framework);
+        }
+      }
+
+      // Fire qualify_lead if strict criteria met (email + phone + click_id)
+      if (meetsQualifyConditions(formSubmitPayload)) {
+        var qualifyLeadPayload = createQualifyLeadPayload(formSubmitPayload, framework, {
+          lead_currency: options.lead_currency,
+          lead_value: options.lead_value
+        });
+        pushToDataLayer(qualifyLeadPayload, {
+          debug: options.debug,
+          framework: framework
+        });
+
+        // Record qualify_lead event server-side
         if (clickId) {
-          recordEvent(clickId, 'generate_lead', options.debug);
+          recordEvent(clickId, 'qualify_lead', options.debug);
+        }
+
+        // DEPRECATED: Dual-fire old generate_lead with strict payload for one version
+        var deprecatedPayload = createQualifyLeadPayload(formSubmitPayload, framework, {
+          lead_currency: options.lead_currency,
+          lead_value: options.lead_value
+        });
+        deprecatedPayload.event = "generate_lead";
+        deprecatedPayload.cuft_deprecated = true;
+        deprecatedPayload.cuft_migrate_to = "qualify_lead";
+        pushToDataLayer(deprecatedPayload, {
+          debug: options.debug,
+          framework: framework
+        });
+
+        if (options.console_logging === "yes" || (options.debug && window.console)) {
+          console.warn('[CUFT] "generate_lead" with strict criteria is deprecated. Update your GTM trigger to use "qualify_lead" instead.');
         }
 
         if (options.debug && window.console && window.console.log) {
-          window.console.log('[CUFT DataLayer] ✅ generate_lead event fired for:', framework);
-        }
-      } else {
-        if (options.debug && window.console && window.console.log) {
-          window.console.log('[CUFT DataLayer] ❌ generate_lead NOT fired for:', framework, 'Missing requirements');
+          window.console.log('[CUFT DataLayer] qualify_lead event fired for:', framework);
         }
       }
 
@@ -483,11 +519,13 @@ window.cuftDataLayerUtils = (function () {
     generateTimestamp: generateTimestamp,
     isFormProcessed: isFormProcessed,
     markFormProcessed: markFormProcessed,
-    meetsLeadConditions: meetsLeadConditions,
+    meetsQualifyConditions: meetsQualifyConditions,
+    meetsGenerateLeadConditions: meetsGenerateLeadConditions,
 
     // Event creation functions
     createFormSubmitPayload: createFormSubmitPayload,
     createGenerateLeadPayload: createGenerateLeadPayload,
+    createQualifyLeadPayload: createQualifyLeadPayload,
     pushToDataLayer: pushToDataLayer,
 
     // Event recording functions (v3.12.0)

--- a/assets/cuft-dataLayer-utils.js
+++ b/assets/cuft-dataLayer-utils.js
@@ -150,6 +150,24 @@ window.cuftDataLayerUtils = (function () {
   }
 
   /**
+   * Extract GA4 client_id from _ga cookie
+   */
+  function getGaClientId() {
+    try {
+      var cookie = document.cookie.match(/(^|; )_ga=([^;]*)/);
+      if (cookie && cookie[2]) {
+        var parts = cookie[2].split(".");
+        if (parts.length >= 4) {
+          return parts[2] + "." + parts[3];
+        }
+      }
+    } catch (e) {
+      // Silently fail — ga_client_id is optional
+    }
+    return null;
+  }
+
+  /**
    * Create standardized form_submit event payload
    */
   function createFormSubmitPayload(framework, formId, options) {
@@ -226,6 +244,12 @@ window.cuftDataLayerUtils = (function () {
       if (!payload.click_id && window.cuftClickData.click_id) {
         payload.click_id = window.cuftClickData.click_id;
       }
+    }
+
+    // Add GA4 client_id for Measurement Protocol
+    var gaClientId = getGaClientId();
+    if (gaClientId) {
+      payload.ga_client_id = gaClientId;
     }
 
     return payload;
@@ -313,7 +337,7 @@ window.cuftDataLayerUtils = (function () {
    * Record event to click tracking database via AJAX
    * Fire-and-forget pattern with silent failures
    */
-  function recordEvent(clickId, eventType, debugMode) {
+  function recordEvent(clickId, eventType, debugMode, gaClientId) {
     try {
       // Validate inputs
       if (!clickId || !eventType) {
@@ -328,6 +352,17 @@ window.cuftDataLayerUtils = (function () {
         return;
       }
 
+      // Build POST params
+      var postParams = {
+        action: "cuft_record_event",
+        nonce: window.cuftConfig.nonce,
+        click_id: clickId,
+        event_type: eventType,
+      };
+      if (gaClientId) {
+        postParams.ga_client_id = gaClientId;
+      }
+
       // Fire-and-forget: Use fetch if available, fallback to XMLHttpRequest
       if (typeof fetch !== "undefined") {
         fetch(window.cuftConfig.ajaxUrl, {
@@ -335,12 +370,7 @@ window.cuftDataLayerUtils = (function () {
           headers: {
             "Content-Type": "application/x-www-form-urlencoded",
           },
-          body: new URLSearchParams({
-            action: "cuft_record_event",
-            nonce: window.cuftConfig.nonce,
-            click_id: clickId,
-            event_type: eventType,
-          }),
+          body: new URLSearchParams(postParams),
         })
           .then(function (response) {
             if (response.ok && debugMode && window.console) {
@@ -364,6 +394,10 @@ window.cuftDataLayerUtils = (function () {
           "&nonce=" + encodeURIComponent(window.cuftConfig.nonce) +
           "&click_id=" + encodeURIComponent(clickId) +
           "&event_type=" + encodeURIComponent(eventType);
+
+        if (gaClientId) {
+          params += "&ga_client_id=" + encodeURIComponent(gaClientId);
+        }
 
         xhr.onreadystatechange = function () {
           if (xhr.readyState === 4 && xhr.status === 200 && debugMode && window.console) {
@@ -441,8 +475,9 @@ window.cuftDataLayerUtils = (function () {
 
       // Record form_submit event to click tracking database (fire-and-forget)
       var clickId = getClickIdFromTracking();
+      var gaClientId = formSubmitPayload.ga_client_id || null;
       if (clickId) {
-        recordEvent(clickId, 'form_submit', options.debug);
+        recordEvent(clickId, 'form_submit', options.debug, gaClientId);
       }
 
       // Fire generate_lead if email is present (broad GA4 meaning)
@@ -474,7 +509,7 @@ window.cuftDataLayerUtils = (function () {
 
         // Record qualify_lead event server-side
         if (clickId) {
-          recordEvent(clickId, 'qualify_lead', options.debug);
+          recordEvent(clickId, 'qualify_lead', options.debug, gaClientId);
         }
 
         // DEPRECATED: Dual-fire old generate_lead with strict payload for one version
@@ -531,6 +566,7 @@ window.cuftDataLayerUtils = (function () {
     // Event recording functions (v3.12.0)
     recordEvent: recordEvent,
     getClickIdFromTracking: getClickIdFromTracking,
+    getGaClientId: getGaClientId,
 
     // Data access
     getTrackingParameters: getTrackingParameters,

--- a/choice-universal-form-tracker.php
+++ b/choice-universal-form-tracker.php
@@ -2,7 +2,7 @@
 /**
  * Plugin Name:       Choice Universal Form Tracker
  * Description:       Universal form tracking for WordPress - supports Avada, Elementor Pro, Contact Form 7, Ninja Forms, Gravity Forms, and more. Tracks submissions and link clicks via Google Tag Manager's dataLayer.
- * Version:           3.21.10
+ * Version:           3.22.0
  * Author:            Choice OMG
  * Author URI:        https://choice.marketing
  * Text Domain:       choice-universal-form-tracker
@@ -14,7 +14,7 @@ if ( ! defined( 'ABSPATH' ) ) {
 }
 
 // Plugin constants
-define( 'CUFT_VERSION', '3.21.10' );
+define( 'CUFT_VERSION', '3.22.0' );
 define( 'CUFT_URL', untrailingslashit( plugins_url( '', __FILE__ ) ) );
 define( 'CUFT_PATH', plugin_dir_path( __FILE__ ) );
 define( 'CUFT_BASENAME', plugin_basename( __FILE__ ) );

--- a/choice-universal-form-tracker.php
+++ b/choice-universal-form-tracker.php
@@ -137,6 +137,7 @@ class Choice_Universal_Form_Tracker {
             // Migrations
             'includes/migrations/class-cuft-migration-3-12-0.php',
             'includes/migrations/class-cuft-migration-3-21-0.php',
+            'includes/migrations/class-cuft-migration-3-22-0.php',
             'includes/migrations/create-update-log-table.php',  // Update log table migration
             // Update System (Feature 008 - v3.17.0)
             'includes/update/class-cuft-plugin-info.php',  // plugins_api filter for update modal

--- a/choice-universal-form-tracker.php
+++ b/choice-universal-form-tracker.php
@@ -73,6 +73,7 @@ class Choice_Universal_Form_Tracker {
             'includes/class-cuft-phone-validator.php',
             'includes/class-cuft-utils.php',
             'includes/class-cuft-migration-events.php',
+            'includes/class-cuft-measurement-protocol.php',
             'includes/class-cuft-cryptojs.php',
             // Form Builder Infrastructure
             'includes/admin/framework-adapters/abstract-cuft-adapter.php',  // Base adapter

--- a/choice-universal-form-tracker.php
+++ b/choice-universal-form-tracker.php
@@ -92,6 +92,7 @@ class Choice_Universal_Form_Tracker {
             'includes/class-cuft-form-builder-validator.php',  // Compliance validator
             // AJAX Handlers
             'includes/ajax/class-cuft-event-recorder.php',  // AJAX event recording handler
+            'includes/ajax/class-cuft-event-replay.php',    // AJAX event replay for webhook events
             'includes/ajax/class-cuft-test-data-generator.php',  // Test data generator AJAX
             'includes/ajax/class-cuft-event-simulator.php',  // Event simulator AJAX
             'includes/ajax/class-cuft-test-form-builder.php',  // Test form builder AJAX
@@ -269,6 +270,11 @@ class Choice_Universal_Form_Tracker {
             // Initialize AJAX Event Recorder (v3.12.0)
             if ( class_exists( 'CUFT_Event_Recorder' ) ) {
                 new CUFT_Event_Recorder();
+            }
+
+            // Initialize AJAX Event Replay for webhook-driven lifecycle events
+            if ( class_exists( 'CUFT_Event_Replay' ) ) {
+                new CUFT_Event_Replay();
             }
 
             // Initialize Testing Dashboard (v3.14.0)

--- a/docs/superpowers/plans/2026-04-02-ga4-event-naming.md
+++ b/docs/superpowers/plans/2026-04-02-ga4-event-naming.md
@@ -1,0 +1,1530 @@
+# GA4 Event Naming & Lead Lifecycle Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Adopt GA4 recommended lead generation event naming, extend the webhook to support the full lead lifecycle, add Measurement Protocol server-side firing, and enable client-side event replay for webhook-driven events.
+
+**Architecture:** Incremental migration in 10 tasks. DB schema first, then JS event renaming with dual-fire deprecation, PHP event constants, admin settings for secrets, webhook extension, Measurement Protocol class, and client-side replay queue. Each task is independently testable and committable.
+
+**Tech Stack:** PHP 7.4+ (WordPress plugin), vanilla JavaScript (no build step), WordPress `dbDelta()` for schema changes, GA4 Measurement Protocol REST API, WordPress AJAX for event replay.
+
+**Spec:** `docs/superpowers/specs/2026-04-02-ga4-event-naming-design.md`
+
+---
+
+## File Structure
+
+### New Files
+- `includes/migrations/class-cuft-migration-3-22-0.php` — DB migration for `ga_client_id` and `replayed_at` columns
+- `includes/class-cuft-measurement-protocol.php` — GA4 Measurement Protocol client
+- `includes/ajax/class-cuft-event-replay.php` — AJAX endpoint for pending event replay
+
+### Modified Files
+- `choice-universal-form-tracker.php` — Version bump, class loading, activation hook
+- `includes/class-cuft-db-migration.php` — Register new migration
+- `assets/cuft-dataLayer-utils.js` — Event renaming (generate_lead → qualify_lead, new broad generate_lead, dual-fire)
+- `includes/class-cuft-click-tracker.php` — Webhook `status` parameter, ga_client_id capture, valid events update, MP integration
+- `includes/ajax/class-cuft-event-recorder.php` — Updated VALID_EVENT_TYPES
+- `includes/class-cuft-admin.php` — New settings fields (register secret, measurement ID, API secret)
+- `includes/class-cuft-token-manager.php` — Fallback to DB option for register secret
+- `includes/class-cuft-utils.php` — Updated display names and icons for new events
+- `tests/standalone/lib/test-data.js` — Updated expected events
+
+---
+
+## Task 1: DB Migration — Add `ga_client_id` and `replayed_at` Columns
+
+**Files:**
+- Create: `includes/migrations/class-cuft-migration-3-22-0.php`
+- Modify: `includes/class-cuft-db-migration.php:16,40-50`
+- Test: `tests/unit/test-migration-3-22-0.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-migration-3-22-0.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Migration_3_22_0 extends TestCase {
+
+    public function test_migration_adds_ga_client_id_column() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $migration = new CUFT_Migration_3_22_0();
+        $migration->up();
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+        $this->assertContains( 'ga_client_id', $columns );
+    }
+
+    public function test_migration_adds_replayed_at_column() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        // up() already ran in previous test, but safe to call again
+        $migration = new CUFT_Migration_3_22_0();
+        $migration->up();
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+        $this->assertContains( 'replayed_at', $columns );
+    }
+
+    public function test_needs_migration_returns_true_before_running() {
+        delete_option( 'cuft_migration_3_22_0_completed' );
+        $migration = new CUFT_Migration_3_22_0();
+        $this->assertTrue( $migration->needs_migration() );
+    }
+
+    public function test_needs_migration_returns_false_after_running() {
+        $migration = new CUFT_Migration_3_22_0();
+        $migration->up();
+        $this->assertFalse( $migration->needs_migration() );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-migration-3-22-0.php"`
+Expected: FAIL — class CUFT_Migration_3_22_0 not found
+
+- [ ] **Step 3: Create migration class**
+
+```php
+<?php
+// includes/migrations/class-cuft-migration-3-22-0.php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Migration_3_22_0 {
+
+    const OPTION_KEY = 'cuft_migration_3_22_0_completed';
+
+    public function up() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+
+        if ( ! in_array( 'ga_client_id', $columns, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN ga_client_id varchar(255) DEFAULT NULL AFTER ip_hash" );
+        }
+
+        if ( ! in_array( 'replayed_at', $columns, true ) ) {
+            $wpdb->query( "ALTER TABLE $table ADD COLUMN replayed_at datetime DEFAULT NULL AFTER events" );
+        }
+
+        update_option( self::OPTION_KEY, true );
+    }
+
+    public function needs_migration() {
+        return ! get_option( self::OPTION_KEY, false );
+    }
+}
+```
+
+- [ ] **Step 4: Register migration in CUFT_DB_Migration**
+
+In `includes/class-cuft-db-migration.php`, update:
+
+```php
+// Change line 16
+const CURRENT_VERSION = '3.22.0';
+```
+
+Add after the v3.21.0 migration call (around line 50):
+
+```php
+if ( version_compare( $current_version, '3.22.0', '<' ) ) {
+    require_once CUFT_PATH . 'includes/migrations/class-cuft-migration-3-22-0.php';
+    $migration = new CUFT_Migration_3_22_0();
+    if ( $migration->needs_migration() ) {
+        $migration->up();
+    }
+}
+```
+
+- [ ] **Step 5: Load migration class in main plugin file**
+
+In `choice-universal-form-tracker.php`, add after the existing migration requires (around the class loading section):
+
+```php
+require_once CUFT_PATH . 'includes/migrations/class-cuft-migration-3-22-0.php';
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-migration-3-22-0.php"`
+Expected: PASS (4 tests, 4 assertions)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add includes/migrations/class-cuft-migration-3-22-0.php includes/class-cuft-db-migration.php choice-universal-form-tracker.php tests/unit/test-migration-3-22-0.php
+git commit -m "feat: Add DB migration 3.22.0 for ga_client_id and replayed_at columns"
+```
+
+---
+
+## Task 2: Update PHP Event Constants and Display Helpers
+
+**Files:**
+- Modify: `includes/ajax/class-cuft-event-recorder.php:21-26`
+- Modify: `includes/class-cuft-click-tracker.php:845-852`
+- Modify: `includes/class-cuft-utils.php:236-264`
+- Modify: `includes/class-cuft-admin.php:1801-1802` (admin filter dropdown)
+- Test: `tests/unit/test-event-constants.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-event-constants.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Event_Constants extends TestCase {
+
+    public function test_event_recorder_includes_qualify_lead() {
+        $valid = CUFT_Event_Recorder::VALID_EVENT_TYPES;
+        $this->assertContains( 'qualify_lead', $valid );
+    }
+
+    public function test_event_recorder_includes_generate_lead() {
+        $valid = CUFT_Event_Recorder::VALID_EVENT_TYPES;
+        $this->assertContains( 'generate_lead', $valid );
+    }
+
+    public function test_utils_display_name_for_qualify_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'qualify_lead' );
+        $this->assertEquals( 'Qualify Lead', $name );
+    }
+
+    public function test_utils_display_name_for_disqualify_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'disqualify_lead' );
+        $this->assertEquals( 'Disqualify Lead', $name );
+    }
+
+    public function test_utils_display_name_for_working_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'working_lead' );
+        $this->assertEquals( 'Working Lead', $name );
+    }
+
+    public function test_utils_display_name_for_close_convert_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'close_convert_lead' );
+        $this->assertEquals( 'Close Convert Lead', $name );
+    }
+
+    public function test_utils_display_name_for_close_unconvert_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'close_unconvert_lead' );
+        $this->assertEquals( 'Close Unconvert Lead', $name );
+    }
+
+    public function test_utils_icon_for_qualify_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'qualify_lead' );
+        $this->assertEquals( '⭐', $icon );
+    }
+
+    public function test_utils_icon_for_working_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'working_lead' );
+        $this->assertEquals( '📋', $icon );
+    }
+
+    public function test_utils_icon_for_close_convert_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'close_convert_lead' );
+        $this->assertEquals( '✅', $icon );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-event-constants.php"`
+Expected: FAIL — qualify_lead not in VALID_EVENT_TYPES
+
+- [ ] **Step 3: Update CUFT_Event_Recorder::VALID_EVENT_TYPES**
+
+In `includes/ajax/class-cuft-event-recorder.php`, replace lines 21-26:
+
+```php
+const VALID_EVENT_TYPES = array(
+    'phone_click',
+    'email_click',
+    'form_submit',
+    'generate_lead',
+    'qualify_lead',
+);
+```
+
+- [ ] **Step 4: Update valid events in CUFT_Click_Tracker**
+
+In `includes/class-cuft-click-tracker.php`, replace the `$valid_events` array (lines 845-852):
+
+```php
+$valid_events = array(
+    'phone_click',
+    'email_click',
+    'form_submit',
+    'generate_lead',
+    'qualify_lead',
+    'disqualify_lead',
+    'working_lead',
+    'close_convert_lead',
+    'close_unconvert_lead',
+    'score_updated',
+);
+```
+
+- [ ] **Step 5: Update CUFT_Utils::get_event_display_name()**
+
+In `includes/class-cuft-utils.php`, replace lines 236-246:
+
+```php
+public static function get_event_display_name( $event_type ) {
+    $display_names = array(
+        'phone_click'          => 'Phone Click',
+        'email_click'          => 'Email Click',
+        'form_submit'          => 'Form Submit',
+        'generate_lead'        => 'Generate Lead',
+        'qualify_lead'         => 'Qualify Lead',
+        'disqualify_lead'      => 'Disqualify Lead',
+        'working_lead'         => 'Working Lead',
+        'close_convert_lead'   => 'Close Convert Lead',
+        'close_unconvert_lead' => 'Close Unconvert Lead',
+        'score_updated'        => 'Score Updated',
+        'status_update'        => 'Status Update',
+    );
+    return isset( $display_names[ $event_type ] ) ? $display_names[ $event_type ] : $event_type;
+}
+```
+
+- [ ] **Step 6: Update CUFT_Utils::get_event_icon()**
+
+In `includes/class-cuft-utils.php`, replace lines 254-264:
+
+```php
+public static function get_event_icon( $event_type ) {
+    $icons = array(
+        'phone_click'          => '📞',
+        'email_click'          => '📧',
+        'form_submit'          => '📝',
+        'generate_lead'        => '🎯',
+        'qualify_lead'         => '⭐',
+        'disqualify_lead'      => '❌',
+        'working_lead'         => '📋',
+        'close_convert_lead'   => '✅',
+        'close_unconvert_lead' => '🚫',
+        'score_updated'        => '📊',
+        'status_update'        => '🔄',
+    );
+    return isset( $icons[ $event_type ] ) ? $icons[ $event_type ] : '●';
+}
+```
+
+- [ ] **Step 7: Update admin filter dropdown**
+
+In `includes/class-cuft-admin.php`, find the event type filter dropdown (around lines 1800-1803) and add the new event types:
+
+```php
+<option value="qualify_lead" <?php selected( $event_filter, 'qualify_lead' ); ?>>Qualify Lead</option>
+<option value="disqualify_lead" <?php selected( $event_filter, 'disqualify_lead' ); ?>>Disqualify Lead</option>
+<option value="working_lead" <?php selected( $event_filter, 'working_lead' ); ?>>Working Lead</option>
+<option value="close_convert_lead" <?php selected( $event_filter, 'close_convert_lead' ); ?>>Close Convert Lead</option>
+<option value="close_unconvert_lead" <?php selected( $event_filter, 'close_unconvert_lead' ); ?>>Close Unconvert Lead</option>
+```
+
+- [ ] **Step 8: Run tests to verify they pass**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-event-constants.php"`
+Expected: PASS (10 tests, 10 assertions)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add includes/ajax/class-cuft-event-recorder.php includes/class-cuft-click-tracker.php includes/class-cuft-utils.php includes/class-cuft-admin.php tests/unit/test-event-constants.php
+git commit -m "feat: Add GA4 lifecycle event types to PHP constants and display helpers"
+```
+
+---
+
+## Task 3: JS Event Renaming — `generate_lead` → `qualify_lead` + New Broad `generate_lead`
+
+**Files:**
+- Modify: `assets/cuft-dataLayer-utils.js:110-123,230-254,397-472`
+- Modify: `tests/standalone/lib/test-data.js:193`
+
+- [ ] **Step 1: Update `meetsLeadConditions()` to `meetsQualifyConditions()`**
+
+In `assets/cuft-dataLayer-utils.js`, rename the function at lines 110-123:
+
+```javascript
+function meetsQualifyConditions(payload) {
+  // Must have valid email and phone
+  if (!payload.user_email || !payload.user_phone) {
+    return false;
+  }
+
+  // Must have at least one click ID
+  for (var i = 0; i < CLICK_ID_FIELDS.length; i++) {
+    if (payload[CLICK_ID_FIELDS[i]]) {
+      return true;
+    }
+  }
+  return false;
+}
+```
+
+- [ ] **Step 2: Add `meetsGenerateLeadConditions()` function**
+
+Add after `meetsQualifyConditions()`:
+
+```javascript
+function meetsGenerateLeadConditions(payload) {
+  return !!payload.user_email;
+}
+```
+
+- [ ] **Step 3: Rename `createGenerateLeadPayload()` to `createQualifyLeadPayload()`**
+
+In `assets/cuft-dataLayer-utils.js`, at the function starting around line 230, rename and update the event name:
+
+```javascript
+function createQualifyLeadPayload(formSubmitPayload, framework, options) {
+  var fw = FRAMEWORK_IDENTIFIERS[framework] || FRAMEWORK_IDENTIFIERS.elementor;
+  var payload = {};
+  for (var key in formSubmitPayload) {
+    if (formSubmitPayload.hasOwnProperty(key)) {
+      payload[key] = formSubmitPayload[key];
+    }
+  }
+  payload.event = "qualify_lead";
+  payload.cuft_source = fw.cuft_source_lead;
+  payload.currency = options.lead_currency || "CAD";
+  payload.value = parseFloat(options.lead_value) || 100;
+  return payload;
+}
+```
+
+- [ ] **Step 4: Add `createGenerateLeadPayload()` for the new broad meaning**
+
+Add after `createQualifyLeadPayload()`:
+
+```javascript
+function createGenerateLeadPayload(formSubmitPayload, framework, options) {
+  var fw = FRAMEWORK_IDENTIFIERS[framework] || FRAMEWORK_IDENTIFIERS.elementor;
+  var payload = {};
+  for (var key in formSubmitPayload) {
+    if (formSubmitPayload.hasOwnProperty(key)) {
+      payload[key] = formSubmitPayload[key];
+    }
+  }
+  payload.event = "generate_lead";
+  payload.cuft_source = fw.cuft_source_lead;
+  payload.currency = options.lead_currency || "CAD";
+  payload.value = parseFloat(options.lead_value) || 100;
+  return payload;
+}
+```
+
+- [ ] **Step 5: Update `trackFormSubmission()` firing logic**
+
+In `assets/cuft-dataLayer-utils.js`, replace the generate_lead section of `trackFormSubmission()` (around lines 420-465). After the `form_submit` push (line 404), replace the lead logic with:
+
+```javascript
+// Fire generate_lead if email is present (broad GA4 meaning)
+if (meetsGenerateLeadConditions(formSubmitPayload)) {
+  var generateLeadPayload = createGenerateLeadPayload(formSubmitPayload, framework, options);
+  pushToDataLayer(generateLeadPayload, {
+    debug: options.debug,
+    framework: framework
+  });
+}
+
+// Fire qualify_lead if strict criteria met (email + phone + click_id)
+if (meetsQualifyConditions(formSubmitPayload)) {
+  var qualifyLeadPayload = createQualifyLeadPayload(formSubmitPayload, framework, options);
+  pushToDataLayer(qualifyLeadPayload, {
+    debug: options.debug,
+    framework: framework
+  });
+
+  // Record qualify_lead event server-side
+  recordEvent(formSubmitPayload, "qualify_lead", options);
+
+  // DEPRECATED: Dual-fire old generate_lead with strict payload for one version
+  var deprecatedPayload = createQualifyLeadPayload(formSubmitPayload, framework, options);
+  deprecatedPayload.event = "generate_lead";
+  deprecatedPayload.cuft_deprecated = true;
+  deprecatedPayload.cuft_migrate_to = "qualify_lead";
+  pushToDataLayer(deprecatedPayload, {
+    debug: options.debug,
+    framework: framework
+  });
+
+  if (options.console_logging === "yes") {
+    console.warn('[CUFT] "generate_lead" with strict criteria is deprecated. Update your GTM trigger to use "qualify_lead" instead.');
+  }
+}
+```
+
+- [ ] **Step 6: Update test data**
+
+In `tests/standalone/lib/test-data.js`, update the expected events section (around line 193). Add after `expectedFormSubmitEvent`:
+
+```javascript
+expectedGenerateLeadEvent: {
+  event: "generate_lead",
+  cuft_tracked: true,
+  cuft_source: "elementor_pro_lead",
+  form_type: "elementor",
+  form_id: "test-form-1",
+  user_email: "test@example.com",
+  currency: "CAD",
+  value: 100
+},
+expectedQualifyLeadEvent: {
+  event: "qualify_lead",
+  cuft_tracked: true,
+  cuft_source: "elementor_pro_lead",
+  form_type: "elementor",
+  form_id: "test-form-1",
+  user_email: "test@example.com",
+  user_phone: "+15551234567",
+  currency: "CAD",
+  value: 100
+},
+```
+
+- [ ] **Step 7: Manual browser test**
+
+Open `http://localhost:8080/cuft-test-forms/` in a browser. Open DevTools console. Submit a test form with email only — verify `form_submit` and `generate_lead` fire. Submit with email + phone + click_id — verify `form_submit`, `generate_lead`, `qualify_lead`, and deprecated `generate_lead` (with `cuft_deprecated: true`) all fire.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add assets/cuft-dataLayer-utils.js tests/standalone/lib/test-data.js
+git commit -m "feat: Rename generate_lead to qualify_lead, add broad generate_lead, dual-fire deprecation"
+```
+
+---
+
+## Task 4: Capture `ga_client_id` at Form Submission
+
+**Files:**
+- Modify: `assets/cuft-dataLayer-utils.js:158-222` (createFormSubmitPayload)
+- Modify: `includes/class-cuft-click-tracker.php` (store ga_client_id on click record)
+
+- [ ] **Step 1: Add GA client_id extraction to JS payload**
+
+In `assets/cuft-dataLayer-utils.js`, add a helper function after the existing helpers (around line 143):
+
+```javascript
+function getGaClientId() {
+  try {
+    var cookie = document.cookie.match(/(^|; )_ga=([^;]*)/);
+    if (cookie && cookie[2]) {
+      // _ga cookie format: GA1.1.XXXXXXX.YYYYYYY — client_id is the last two parts
+      var parts = cookie[2].split(".");
+      if (parts.length >= 4) {
+        return parts[2] + "." + parts[3];
+      }
+    }
+  } catch (e) {
+    // Silently fail — ga_client_id is optional
+  }
+  return null;
+}
+```
+
+- [ ] **Step 2: Include ga_client_id in form submit payload**
+
+In `createFormSubmitPayload()` (around line 158), add after the existing fields:
+
+```javascript
+var gaClientId = getGaClientId();
+if (gaClientId) {
+  payload.ga_client_id = gaClientId;
+}
+```
+
+- [ ] **Step 3: Store ga_client_id in click tracker PHP**
+
+In `includes/class-cuft-click-tracker.php`, find where click records are inserted/updated on form submission. In the method that handles recording a click (the `record_click()` or similar method that saves to `cuft_click_tracking`), add `ga_client_id` to the data being saved:
+
+```php
+if ( ! empty( $data['ga_client_id'] ) ) {
+    $wpdb->update(
+        $table_name,
+        array( 'ga_client_id' => sanitize_text_field( $data['ga_client_id'] ) ),
+        array( 'click_id' => $click_id ),
+        array( '%s' ),
+        array( '%s' )
+    );
+}
+```
+
+- [ ] **Step 4: Manual browser test**
+
+Submit a form on a page that has GA4 running. Check the `cuft_click_tracking` table:
+
+```bash
+docker exec wp-pdev-cli wp db query "SELECT click_id, ga_client_id FROM wp_cuft_click_tracking ORDER BY id DESC LIMIT 5"
+```
+
+Verify `ga_client_id` is populated.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add assets/cuft-dataLayer-utils.js includes/class-cuft-click-tracker.php
+git commit -m "feat: Capture GA client_id from _ga cookie at form submission"
+```
+
+---
+
+## Task 5: Admin Settings for Secrets
+
+**Files:**
+- Modify: `includes/class-cuft-admin.php:166-237,512-579`
+- Modify: `includes/class-cuft-token-manager.php:39-44`
+- Test: `tests/unit/test-admin-secrets.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-admin-secrets.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Admin_Secrets extends TestCase {
+
+    public function test_register_secret_falls_back_to_option() {
+        // Ensure constant is not defined (it won't be in test env)
+        update_option( 'cuft_register_secret', 'test-secret-from-db' );
+
+        $secret = CUFT_Token_Manager::get_register_secret_value();
+        $this->assertEquals( 'test-secret-from-db', $secret );
+
+        delete_option( 'cuft_register_secret' );
+    }
+
+    public function test_measurement_id_option() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        $this->assertEquals( 'G-TEST123', get_option( 'cuft_measurement_id', '' ) );
+        delete_option( 'cuft_measurement_id' );
+    }
+
+    public function test_measurement_api_secret_option() {
+        update_option( 'cuft_measurement_api_secret', 'secret123' );
+        $this->assertEquals( 'secret123', get_option( 'cuft_measurement_api_secret', '' ) );
+        delete_option( 'cuft_measurement_api_secret' );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-admin-secrets.php"`
+Expected: FAIL — `get_register_secret_value` method doesn't exist
+
+- [ ] **Step 3: Update CUFT_Token_Manager to expose secret retrieval with DB fallback**
+
+In `includes/class-cuft-token-manager.php`, replace the private `get_register_secret()` method (lines 39-44):
+
+```php
+/**
+ * Get the registration secret. wp-config.php constant takes precedence,
+ * then falls back to the DB option.
+ */
+public static function get_register_secret_value(): string {
+    if ( defined( 'CUFT_REGISTER_SECRET' ) ) {
+        return CUFT_REGISTER_SECRET;
+    }
+    return get_option( 'cuft_register_secret', '' );
+}
+```
+
+Update all internal callers of `get_register_secret()` to use `get_register_secret_value()` — search for `self::get_register_secret()` in the file and replace with `self::get_register_secret_value()`.
+
+- [ ] **Step 4: Add secret settings fields to admin page**
+
+In `includes/class-cuft-admin.php`, find the sGTM settings section (around line 166). Add a new section after it for API credentials:
+
+```php
+<!-- API Credentials Section -->
+<div style="background: #fff; border: 1px solid #ccd0d4; border-radius: 6px; padding: 20px; margin-bottom: 20px;">
+    <h3 style="margin: 0 0 15px; color: #23282d;">API Credentials</h3>
+
+    <?php $register_secret_override = defined( 'CUFT_REGISTER_SECRET' ); ?>
+    <table class="form-table">
+        <tr>
+            <th scope="row"><label for="cuft_register_secret">Registration Secret</label></th>
+            <td>
+                <?php if ( $register_secret_override ) : ?>
+                    <input type="text" value="••••••••" disabled class="regular-text" />
+                    <p class="description">Overridden by <code>CUFT_REGISTER_SECRET</code> in wp-config.php</p>
+                <?php else : ?>
+                    <input type="password" id="cuft_register_secret" name="cuft_register_secret"
+                        value="<?php echo esc_attr( get_option( 'cuft_register_secret', '' ) ); ?>"
+                        class="regular-text" autocomplete="off" />
+                    <p class="description">Authenticates with the validator service. Can also be set as <code>CUFT_REGISTER_SECRET</code> in wp-config.php.</p>
+                <?php endif; ?>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="cuft_measurement_id">GA4 Measurement ID</label></th>
+            <td>
+                <input type="text" id="cuft_measurement_id" name="cuft_measurement_id"
+                    value="<?php echo esc_attr( get_option( 'cuft_measurement_id', '' ) ); ?>"
+                    class="regular-text" placeholder="G-XXXXXXXXXX" />
+                <p class="description">Required for server-side Measurement Protocol events.</p>
+            </td>
+        </tr>
+        <tr>
+            <th scope="row"><label for="cuft_measurement_api_secret">GA4 API Secret</label></th>
+            <td>
+                <input type="password" id="cuft_measurement_api_secret" name="cuft_measurement_api_secret"
+                    value="<?php echo esc_attr( get_option( 'cuft_measurement_api_secret', '' ) ); ?>"
+                    class="regular-text" autocomplete="off" />
+                <p class="description">Found in GA4 Admin → Data Streams → Measurement Protocol API secrets.</p>
+            </td>
+        </tr>
+    </table>
+</div>
+```
+
+- [ ] **Step 5: Save the new options in `save_settings()`**
+
+In `includes/class-cuft-admin.php`, in the `save_settings()` method (around line 540), add after the existing `update_option` calls:
+
+```php
+if ( isset( $_POST['cuft_register_secret'] ) && ! defined( 'CUFT_REGISTER_SECRET' ) ) {
+    update_option( 'cuft_register_secret', sanitize_text_field( wp_unslash( $_POST['cuft_register_secret'] ) ) );
+}
+if ( isset( $_POST['cuft_measurement_id'] ) ) {
+    $measurement_id = sanitize_text_field( wp_unslash( $_POST['cuft_measurement_id'] ) );
+    if ( empty( $measurement_id ) || preg_match( '/^G-[A-Z0-9]+$/', $measurement_id ) ) {
+        update_option( 'cuft_measurement_id', $measurement_id );
+    }
+}
+if ( isset( $_POST['cuft_measurement_api_secret'] ) ) {
+    update_option( 'cuft_measurement_api_secret', sanitize_text_field( wp_unslash( $_POST['cuft_measurement_api_secret'] ) ) );
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-admin-secrets.php"`
+Expected: PASS (3 tests, 3 assertions)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add includes/class-cuft-admin.php includes/class-cuft-token-manager.php tests/unit/test-admin-secrets.php
+git commit -m "feat: Add admin settings for registration secret, GA4 Measurement ID, and API secret"
+```
+
+---
+
+## Task 6: Extend Webhook with `status` Parameter
+
+**Files:**
+- Modify: `includes/class-cuft-click-tracker.php:186-253,470-513`
+- Test: `tests/unit/test-webhook-status.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-webhook-status.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Webhook_Status extends TestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        global $wpdb;
+        // Insert a test click
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-webhook-click',
+            'platform'     => 'google',
+            'qualified'    => 0,
+            'score'        => 0,
+            'ga_client_id' => '123456.789012',
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-webhook-click' ) );
+    }
+
+    public function test_valid_status_values() {
+        $valid = CUFT_Click_Tracker::get_valid_webhook_statuses();
+        $this->assertContains( 'qualify_lead', $valid );
+        $this->assertContains( 'disqualify_lead', $valid );
+        $this->assertContains( 'working_lead', $valid );
+        $this->assertContains( 'close_convert_lead', $valid );
+        $this->assertContains( 'close_unconvert_lead', $valid );
+    }
+
+    public function test_status_parameter_records_event() {
+        global $wpdb;
+        CUFT_Click_Tracker::update_click_status( 'test-webhook-click', null, null, 'working_lead' );
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-webhook-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'working_lead', $last_event['event_type'] );
+    }
+
+    public function test_qualified_param_maps_to_qualify_lead() {
+        global $wpdb;
+        CUFT_Click_Tracker::update_click_status( 'test-webhook-click', 1 );
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-webhook-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'qualify_lead', $last_event['event_type'] );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-webhook-status.php"`
+Expected: FAIL — `get_valid_webhook_statuses` doesn't exist
+
+- [ ] **Step 3: Add `get_valid_webhook_statuses()` static method**
+
+In `includes/class-cuft-click-tracker.php`, add a new static method:
+
+```php
+public static function get_valid_webhook_statuses() {
+    return array(
+        'qualify_lead',
+        'disqualify_lead',
+        'working_lead',
+        'close_convert_lead',
+        'close_unconvert_lead',
+    );
+}
+```
+
+- [ ] **Step 4: Update `update_click_status()` to accept `$status` parameter**
+
+In `includes/class-cuft-click-tracker.php`, update the method signature at line 186:
+
+```php
+public static function update_click_status( $click_id, $qualified = null, $score = null, $status = null ) {
+```
+
+In the event recording section (around lines 229-245), replace the `status_qualified` logic:
+
+```php
+// Record lifecycle status event
+if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+    $events[] = array(
+        'event_type' => $status,
+        'timestamp'  => current_time( 'mysql' ),
+    );
+} elseif ( $qualified && ( ! $current_record || ! $current_record->qualified ) ) {
+    // Backward compatibility: qualified=1 maps to qualify_lead
+    $events[] = array(
+        'event_type' => 'qualify_lead',
+        'timestamp'  => current_time( 'mysql' ),
+    );
+}
+
+if ( $score && ( ! $current_record || (int) $score > (int) $current_record->score ) ) {
+    $events[] = array(
+        'event_type' => 'score_updated',
+        'timestamp'  => current_time( 'mysql' ),
+    );
+}
+```
+
+- [ ] **Step 5: Update `handle_webhook()` to read `status` parameter**
+
+In `includes/class-cuft-click-tracker.php`, in the `handle_webhook()` method (around line 472), add status extraction:
+
+```php
+$status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : null;
+
+// Validate status if provided
+if ( $status && ! in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+    wp_send_json_error( array(
+        'message' => 'Invalid status value. Valid values: ' . implode( ', ', self::get_valid_webhook_statuses() ),
+    ), 400 );
+    return;
+}
+```
+
+Update the call to `update_click_status()` (around line 501) to pass the status:
+
+```php
+self::update_click_status( $click_id, $qualified, $score, $status );
+```
+
+If `$status` is provided and `$qualified` is not, also set `qualified` based on status:
+
+```php
+// Status=qualify_lead implies qualified=1
+if ( 'qualify_lead' === $status && null === $qualified ) {
+    $qualified = 1;
+}
+```
+
+- [ ] **Step 6: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-webhook-status.php"`
+Expected: PASS (3 tests, 3 assertions)
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add includes/class-cuft-click-tracker.php tests/unit/test-webhook-status.php
+git commit -m "feat: Extend webhook with status parameter for GA4 lifecycle events"
+```
+
+---
+
+## Task 7: Measurement Protocol Client
+
+**Files:**
+- Create: `includes/class-cuft-measurement-protocol.php`
+- Modify: `choice-universal-form-tracker.php` (require new class)
+- Test: `tests/unit/test-measurement-protocol.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-measurement-protocol.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Measurement_Protocol extends TestCase {
+
+    public function test_build_payload_structure() {
+        $mp = new CUFT_Measurement_Protocol();
+        $payload = $mp->build_payload( '123456.789012', 'qualify_lead', array(
+            'click_id'    => 'abc123',
+            'lead_source' => 'gravity_forms',
+        ) );
+
+        $this->assertEquals( '123456.789012', $payload['client_id'] );
+        $this->assertCount( 1, $payload['events'] );
+        $this->assertEquals( 'qualify_lead', $payload['events'][0]['name'] );
+        $this->assertEquals( 'abc123', $payload['events'][0]['params']['click_id'] );
+        $this->assertEquals( 'gravity_forms', $payload['events'][0]['params']['lead_source'] );
+        $this->assertEquals( 1, $payload['events'][0]['params']['engagement_time_msec'] );
+    }
+
+    public function test_build_payload_includes_lead_value() {
+        update_option( 'cuft_lead_value', 250 );
+        update_option( 'cuft_lead_currency', 'USD' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $payload = $mp->build_payload( '123.456', 'close_convert_lead', array() );
+
+        $this->assertEquals( 250, $payload['events'][0]['params']['value'] );
+        $this->assertEquals( 'USD', $payload['events'][0]['params']['currency'] );
+
+        delete_option( 'cuft_lead_value' );
+        delete_option( 'cuft_lead_currency' );
+    }
+
+    public function test_is_configured_returns_false_when_missing() {
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $this->assertFalse( $mp->is_configured() );
+    }
+
+    public function test_is_configured_returns_true_when_set() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        update_option( 'cuft_measurement_api_secret', 'secret' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $this->assertTrue( $mp->is_configured() );
+
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-measurement-protocol.php"`
+Expected: FAIL — class not found
+
+- [ ] **Step 3: Create CUFT_Measurement_Protocol class**
+
+```php
+<?php
+// includes/class-cuft-measurement-protocol.php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Measurement_Protocol {
+
+    const ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+    public function is_configured(): bool {
+        return ! empty( get_option( 'cuft_measurement_id', '' ) )
+            && ! empty( get_option( 'cuft_measurement_api_secret', '' ) );
+    }
+
+    public function build_payload( string $client_id, string $event_name, array $event_params = array() ): array {
+        $lead_value    = get_option( 'cuft_lead_value', 100 );
+        $lead_currency = get_option( 'cuft_lead_currency', 'CAD' );
+
+        $params = array_merge( array(
+            'value'                => (float) $lead_value,
+            'currency'             => $lead_currency,
+            'engagement_time_msec' => 1,
+        ), $event_params );
+
+        return array(
+            'client_id' => $client_id,
+            'events'    => array(
+                array(
+                    'name'   => $event_name,
+                    'params' => $params,
+                ),
+            ),
+        );
+    }
+
+    public function send( string $client_id, string $event_name, array $event_params = array() ): bool {
+        if ( ! $this->is_configured() ) {
+            CUFT_Logger::log( 'Measurement Protocol not configured — skipping event: ' . $event_name );
+            return false;
+        }
+
+        if ( empty( $client_id ) ) {
+            CUFT_Logger::log( 'No ga_client_id available — skipping MP event: ' . $event_name );
+            return false;
+        }
+
+        $measurement_id = get_option( 'cuft_measurement_id', '' );
+        $api_secret     = get_option( 'cuft_measurement_api_secret', '' );
+
+        $url = add_query_arg( array(
+            'measurement_id' => $measurement_id,
+            'api_secret'     => $api_secret,
+        ), self::ENDPOINT );
+
+        $payload = $this->build_payload( $client_id, $event_name, $event_params );
+
+        $response = wp_remote_post( $url, array(
+            'headers' => array( 'Content-Type' => 'application/json' ),
+            'body'    => wp_json_encode( $payload ),
+            'timeout' => 5,
+        ) );
+
+        if ( is_wp_error( $response ) ) {
+            CUFT_Logger::log( 'MP request failed for ' . $event_name . ': ' . $response->get_error_message() );
+            return false;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( $code < 200 || $code >= 300 ) {
+            CUFT_Logger::log( 'MP request returned HTTP ' . $code . ' for ' . $event_name );
+            return false;
+        }
+
+        return true;
+    }
+}
+```
+
+- [ ] **Step 4: Load class in main plugin file**
+
+In `choice-universal-form-tracker.php`, add with the other requires:
+
+```php
+require_once CUFT_PATH . 'includes/class-cuft-measurement-protocol.php';
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-measurement-protocol.php"`
+Expected: PASS (4 tests, 4 assertions)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add includes/class-cuft-measurement-protocol.php choice-universal-form-tracker.php tests/unit/test-measurement-protocol.php
+git commit -m "feat: Add GA4 Measurement Protocol client class"
+```
+
+---
+
+## Task 8: Fire Measurement Protocol from Webhook
+
+**Files:**
+- Modify: `includes/class-cuft-click-tracker.php:186-253` (update_click_status)
+- Test: `tests/unit/test-webhook-mp-integration.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-webhook-mp-integration.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Webhook_MP_Integration extends TestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        global $wpdb;
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-mp-click',
+            'platform'     => 'google',
+            'qualified'    => 0,
+            'score'        => 0,
+            'ga_client_id' => '111111.222222',
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-mp-click' ) );
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+    }
+
+    public function test_webhook_status_fires_mp_when_configured() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        update_option( 'cuft_measurement_api_secret', 'secret' );
+
+        // We can't easily mock wp_remote_post in WP test env, so we verify
+        // the MP class is called by checking it doesn't error out.
+        // The actual HTTP call will fail (test env), but the flow should complete.
+        $result = CUFT_Click_Tracker::update_click_status( 'test-mp-click', null, null, 'qualify_lead' );
+
+        // Verify the event was still recorded in DB regardless of MP result
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-mp-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'qualify_lead', $last_event['event_type'] );
+    }
+
+    public function test_webhook_skips_mp_when_not_configured() {
+        // No measurement options set — should not error
+        $result = CUFT_Click_Tracker::update_click_status( 'test-mp-click', null, null, 'working_lead' );
+
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-mp-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'working_lead', $last_event['event_type'] );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-webhook-mp-integration.php"`
+Expected: FAIL (update_click_status doesn't fire MP yet)
+
+- [ ] **Step 3: Add MP firing to `update_click_status()`**
+
+In `includes/class-cuft-click-tracker.php`, in `update_click_status()`, after the events are recorded in DB (after the `$wpdb->update` call that saves the events JSON), add:
+
+```php
+// Fire Measurement Protocol for webhook-driven lifecycle events
+if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+    $ga_client_id = $wpdb->get_var( $wpdb->prepare(
+        "SELECT ga_client_id FROM $table_name WHERE click_id = %s",
+        sanitize_text_field( $click_id )
+    ) );
+
+    $mp = new CUFT_Measurement_Protocol();
+    $mp->send( $ga_client_id ?: '', $status, array(
+        'click_id'    => $click_id,
+        'lead_source' => $current_record ? ( $current_record->platform ?: 'unknown' ) : 'unknown',
+    ) );
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-webhook-mp-integration.php"`
+Expected: PASS (2 tests, 2 assertions)
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add includes/class-cuft-click-tracker.php tests/unit/test-webhook-mp-integration.php
+git commit -m "feat: Fire Measurement Protocol events from webhook status updates"
+```
+
+---
+
+## Task 9: Client-Side Event Replay
+
+**Files:**
+- Create: `includes/ajax/class-cuft-event-replay.php`
+- Modify: `choice-universal-form-tracker.php` (require + register AJAX)
+- Modify: `assets/cuft-click-integration.js` (add replay check on pageview)
+- Modify: `includes/class-cuft-click-tracker.php` (update_click_status sets replayed_at = NULL for webhook events)
+- Test: `tests/unit/test-event-replay.php`
+
+- [ ] **Step 1: Write the failing test**
+
+```php
+<?php
+// tests/unit/test-event-replay.php
+
+use Yoast\PHPUnitPolyfills\TestCases\TestCase;
+
+class Test_Event_Replay extends TestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        global $wpdb;
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-replay-click',
+            'platform'     => 'google',
+            'qualified'    => 1,
+            'score'        => 0,
+            'ga_client_id' => '111.222',
+            'events'       => wp_json_encode( array(
+                array(
+                    'event_type' => 'form_submit',
+                    'timestamp'  => '2026-04-01 10:00:00',
+                ),
+                array(
+                    'event_type'  => 'qualify_lead',
+                    'timestamp'   => '2026-04-02 14:00:00',
+                    'replayed_at' => null,
+                    'source'      => 'webhook',
+                ),
+            ) ),
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-replay-click' ) );
+    }
+
+    public function test_get_pending_events_returns_unreplayed_webhook_events() {
+        $pending = CUFT_Event_Replay::get_pending_events( 'test-replay-click' );
+        $this->assertCount( 1, $pending );
+        $this->assertEquals( 'qualify_lead', $pending[0]['event_type'] );
+    }
+
+    public function test_mark_events_replayed_sets_timestamp() {
+        CUFT_Event_Replay::mark_events_replayed( 'test-replay-click' );
+
+        $pending = CUFT_Event_Replay::get_pending_events( 'test-replay-click' );
+        $this->assertCount( 0, $pending );
+    }
+}
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-event-replay.php"`
+Expected: FAIL — CUFT_Event_Replay class not found
+
+- [ ] **Step 3: Create CUFT_Event_Replay class**
+
+```php
+<?php
+// includes/ajax/class-cuft-event-replay.php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Event_Replay {
+
+    public function __construct() {
+        add_action( 'wp_ajax_cuft_get_pending_events', array( $this, 'ajax_get_pending' ) );
+        add_action( 'wp_ajax_nopriv_cuft_get_pending_events', array( $this, 'ajax_get_pending' ) );
+    }
+
+    public static function get_pending_events( string $click_id ): array {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s",
+            sanitize_text_field( $click_id )
+        ) );
+
+        if ( ! $row || empty( $row->events ) ) {
+            return array();
+        }
+
+        $events = json_decode( $row->events, true );
+        if ( ! is_array( $events ) ) {
+            return array();
+        }
+
+        $pending = array();
+        foreach ( $events as $event ) {
+            if ( ! empty( $event['source'] ) && 'webhook' === $event['source'] && empty( $event['replayed_at'] ) ) {
+                $pending[] = $event;
+            }
+        }
+
+        return $pending;
+    }
+
+    public static function mark_events_replayed( string $click_id ): void {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s",
+            sanitize_text_field( $click_id )
+        ) );
+
+        if ( ! $row || empty( $row->events ) ) {
+            return;
+        }
+
+        $events  = json_decode( $row->events, true );
+        $updated = false;
+
+        foreach ( $events as &$event ) {
+            if ( ! empty( $event['source'] ) && 'webhook' === $event['source'] && empty( $event['replayed_at'] ) ) {
+                $event['replayed_at'] = current_time( 'mysql' );
+                $updated = true;
+            }
+        }
+
+        if ( $updated ) {
+            $wpdb->update(
+                $table,
+                array( 'events' => wp_json_encode( $events ) ),
+                array( 'click_id' => sanitize_text_field( $click_id ) ),
+                array( '%s' ),
+                array( '%s' )
+            );
+        }
+    }
+
+    public function ajax_get_pending(): void {
+        $click_id = isset( $_GET['click_id'] ) ? sanitize_text_field( wp_unslash( $_GET['click_id'] ) ) : '';
+
+        if ( empty( $click_id ) ) {
+            wp_send_json_success( array( 'events' => array() ) );
+            return;
+        }
+
+        $pending = self::get_pending_events( $click_id );
+
+        if ( ! empty( $pending ) ) {
+            self::mark_events_replayed( $click_id );
+        }
+
+        wp_send_json_success( array( 'events' => $pending ) );
+    }
+}
+```
+
+- [ ] **Step 4: Tag webhook events with `source: 'webhook'` in update_click_status**
+
+In `includes/class-cuft-click-tracker.php`, in the event recording section of `update_click_status()`, update the lifecycle event array to include `source`:
+
+```php
+if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+    $events[] = array(
+        'event_type'  => $status,
+        'timestamp'   => current_time( 'mysql' ),
+        'source'      => 'webhook',
+        'replayed_at' => null,
+    );
+}
+```
+
+- [ ] **Step 5: Load class and register in main plugin file**
+
+In `choice-universal-form-tracker.php`, add the require:
+
+```php
+require_once CUFT_PATH . 'includes/ajax/class-cuft-event-replay.php';
+```
+
+And instantiate in the constructor or init hook where other AJAX handlers are set up:
+
+```php
+new CUFT_Event_Replay();
+```
+
+- [ ] **Step 6: Add JS replay logic to cuft-click-integration.js**
+
+In `assets/cuft-click-integration.js`, after the existing `addClickIdToDataLayer()` call in the ready() callback (around line 144), add:
+
+```javascript
+// Check for pending webhook events to replay
+(function checkPendingEvents() {
+  var clickId = null;
+  try {
+    var match = document.cookie.match(/(^|; )cuft_click_id=([^;]*)/);
+    if (match && match[2]) {
+      clickId = decodeURIComponent(match[2]);
+    }
+  } catch (e) {
+    return;
+  }
+
+  if (!clickId) {
+    return;
+  }
+
+  var xhr = new XMLHttpRequest();
+  xhr.open("GET", (window.cuftAjax ? window.cuftAjax.ajax_url : "/wp-admin/admin-ajax.php") +
+    "?action=cuft_get_pending_events&click_id=" + encodeURIComponent(clickId), true);
+  xhr.onreadystatechange = function () {
+    if (xhr.readyState !== 4 || xhr.status !== 200) return;
+    try {
+      var resp = JSON.parse(xhr.responseText);
+      if (resp.success && resp.data && resp.data.events && resp.data.events.length) {
+        var dl = window.dataLayer || [];
+        for (var i = 0; i < resp.data.events.length; i++) {
+          var evt = resp.data.events[i];
+          dl.push({
+            event: evt.event_type,
+            click_id: clickId,
+            cuft_tracked: true,
+            cuft_source: "webhook_replay",
+            cuft_replayed: true
+          });
+        }
+      }
+    } catch (e) {
+      // Silently fail
+    }
+  };
+  xhr.send();
+})();
+```
+
+- [ ] **Step 7: Run test to verify it passes**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit tests/unit/test-event-replay.php"`
+Expected: PASS (2 tests, 2 assertions)
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add includes/ajax/class-cuft-event-replay.php includes/class-cuft-click-tracker.php choice-universal-form-tracker.php assets/cuft-click-integration.js tests/unit/test-event-replay.php
+git commit -m "feat: Add client-side event replay for webhook-driven lifecycle events"
+```
+
+---
+
+## Task 10: Version Bump and Final Integration
+
+**Files:**
+- Modify: `choice-universal-form-tracker.php:17` (version)
+- Modify: `CHANGELOG.md`
+
+- [ ] **Step 1: Bump version**
+
+In `choice-universal-form-tracker.php`, update:
+
+```php
+// Line 17
+define( 'CUFT_VERSION', '3.22.0' );
+```
+
+Also update the `Version:` header in the plugin docblock to `3.22.0`.
+
+- [ ] **Step 2: Update CHANGELOG.md**
+
+Add at the top of `CHANGELOG.md`:
+
+```markdown
+## [3.22.0] - 2026-04-02
+
+### Added
+- **GA4 event naming alignment** — adopted GA4 recommended lead generation event names
+  - New `qualify_lead` event replaces strict `generate_lead` (email + phone + click_id)
+  - New broad `generate_lead` fires on any form submission with a valid email
+  - Full lifecycle events: `disqualify_lead`, `working_lead`, `close_convert_lead`, `close_unconvert_lead`
+- **Webhook `status` parameter** — send `?status=qualify_lead` (etc.) to record lifecycle events
+  - Backward compatible: `qualified=1` still works, mapped to `qualify_lead`
+- **GA4 Measurement Protocol** — server-side events fire at webhook time
+  - Configurable in Settings: GA4 Measurement ID and API Secret
+  - Graceful fallback when not configured
+- **Client-side event replay** — webhook events pushed to dataLayer on next pageview
+  - Cookie-based (no PHP sessions), fires once per event
+  - `cuft_replayed: true` flag for GTM trigger differentiation
+- **Admin settings for secrets** — Registration Secret, GA4 Measurement ID, and API Secret configurable from wp-admin
+  - `wp-config.php` constants still override DB values
+- **`ga_client_id` capture** — extracted from `_ga` cookie at form submission for Measurement Protocol
+
+### Changed
+- `generate_lead` now fires on any form with a valid email (previously required email + phone + click_id)
+- `status_qualified` webhook event renamed to `qualify_lead`
+
+### Deprecated
+- `generate_lead` with strict criteria (email + phone + click_id) — fires with `cuft_deprecated: true` for one version, then removed. Migrate GTM triggers to `qualify_lead`.
+```
+
+- [ ] **Step 3: Run full test suite**
+
+Run: `docker exec wp-pdev-cli bash -c "cd /var/www/html/wp-content/plugins/choice-uft && vendor/bin/phpunit"`
+Expected: All tests pass
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add choice-universal-form-tracker.php CHANGELOG.md
+git commit -m "chore: Bump version to 3.22.0 with GA4 event naming and lead lifecycle"
+```

--- a/docs/superpowers/specs/2026-04-02-ga4-event-naming-design.md
+++ b/docs/superpowers/specs/2026-04-02-ga4-event-naming-design.md
@@ -1,0 +1,198 @@
+# GA4 Conventional Event Naming & Lead Lifecycle
+
+Adopt GA4 recommended lead generation event naming and extend the plugin to support the full lead lifecycle funnel.
+
+## 1. Event Name Realignment
+
+### Current to New Mapping
+
+| Current Event | New Event | Change |
+|---|---|---|
+| `form_submit` | `form_submit` | No change |
+| `generate_lead` (email+phone+click_id) | `qualify_lead` | Renamed — this logic was always qualification |
+| *(new)* | `generate_lead` | New — fires on any form submission with a valid email |
+| `phone_click` | `phone_click` | No change |
+| `email_click` | `email_click` | No change |
+| `click_id_detected` | `click_id_detected` | No change (internal) |
+| `status_qualified` (webhook) | `qualify_lead` | Merged — same event whether client or webhook triggered |
+| `score_updated` (webhook) | `score_updated` | No change |
+
+### Firing Order on Form Submission
+
+1. `form_submit` — always (every submission)
+2. `generate_lead` — if submission contains a valid email
+3. `qualify_lead` — if submission contains email + phone + click_id
+
+### GA4 Lead Generation Funnel (Full)
+
+| GA4 Event | Trigger |
+|---|---|
+| `generate_lead` | User submits a form with an email address |
+| `qualify_lead` | Lead meets criteria (email + phone + click_id), or marked qualified via webhook |
+| `disqualify_lead` | Lead marked as disqualified via webhook |
+| `working_lead` | Lead contacted by a rep via webhook |
+| `close_convert_lead` | Lead became a customer via webhook |
+| `close_unconvert_lead` | Lead closed without converting via webhook |
+
+## 2. Admin Settings for Secrets
+
+### New Settings
+
+| Setting | Option Key | Description |
+|---|---|---|
+| Registration Secret | `cuft_register_secret` | Authenticates with validator service |
+| GA4 Measurement ID | `cuft_measurement_id` | For Measurement Protocol (e.g., `G-XXXXXXX`) |
+| GA4 API Secret | `cuft_measurement_api_secret` | Measurement Protocol authentication |
+
+### Behavior
+
+- `wp-config.php` constants still work as overrides — if `CUFT_REGISTER_SECRET` is defined, it takes precedence over the DB option.
+- Admin UI shows a masked field when a `wp-config.php` constant is active, with a note explaining the override.
+- Secrets stored encrypted in the DB using WordPress's `AUTH_SALT`.
+
+## 3. Webhook Extension
+
+### Current Contract
+
+```
+GET /cuft-webhook/?click_id=abc&qualified=1&score=85
+```
+
+### New Contract — `status` Parameter
+
+```
+GET /cuft-webhook/?click_id=abc&status=qualify_lead
+GET /cuft-webhook/?click_id=abc&status=disqualify_lead
+GET /cuft-webhook/?click_id=abc&status=working_lead
+GET /cuft-webhook/?click_id=abc&status=close_convert_lead
+GET /cuft-webhook/?click_id=abc&status=close_unconvert_lead
+```
+
+### Valid Status Values
+
+| Status | Description |
+|---|---|
+| `qualify_lead` | Lead meets qualification criteria |
+| `disqualify_lead` | Lead disqualified |
+| `working_lead` | Rep is actively working the lead |
+| `close_convert_lead` | Lead converted to customer |
+| `close_unconvert_lead` | Lead closed without converting |
+
+### Backward Compatibility
+
+- `qualified=1` still works — internally mapped to `status=qualify_lead`.
+- `score` parameter still works alongside any `status` value.
+- If both `qualified=1` and `status=disqualify_lead` are sent, `status` wins (explicit takes precedence).
+- Unknown status values return `400 Bad Request` with an error listing valid options.
+
+### Event Recording
+
+Each webhook call with a valid `status` records an event in the clicks event table (same mechanism as current `status_qualified` and `score_updated`).
+
+## 4. Measurement Protocol (Server-Side)
+
+### When
+
+At webhook time, immediately after recording the event in the DB.
+
+### What Fires
+
+The same GA4 event name as the `status` parameter. A `qualify_lead` webhook pushes a `qualify_lead` event to GA4 via Measurement Protocol.
+
+### Payload
+
+```json
+POST https://www.google-analytics.com/mp/collect?measurement_id={cuft_measurement_id}&api_secret={cuft_measurement_api_secret}
+
+{
+  "client_id": "<ga_client_id from clicks table>",
+  "events": [{
+    "name": "qualify_lead",
+    "params": {
+      "click_id": "abc123",
+      "lead_source": "gravity_forms",
+      "lead_value": 100,
+      "lead_currency": "CAD",
+      "engagement_time_msec": 1
+    }
+  }]
+}
+```
+
+### Requirements
+
+- **New DB column:** `ga_client_id` on the clicks table — captured from the `_ga` cookie at form submission time.
+- **Graceful fallback:** If Measurement ID or API Secret aren't configured, webhook still works normally (no MP fire), logs a debug notice.
+- **Fires for:** All webhook-driven lifecycle events (`qualify_lead` through `close_unconvert_lead`). `generate_lead` and client-side `qualify_lead` fire via dataLayer only (not MP) since they happen in the browser at form submission time.
+- **Value params:** Uses existing `cuft_lead_value` and `cuft_lead_currency` options.
+
+## 5. Client-Side Event Queue (Pageview Replay)
+
+### Mechanism
+
+1. **At webhook time:** After recording the event, queue it with `replayed_at = NULL`.
+2. **On pageview:** JS reads `cuft_click_id` cookie. If present, AJAX call asks the server for pending events for that click_id.
+3. **Server responds** with unreplayed events.
+4. **JS pushes each to dataLayer:**
+
+```javascript
+dataLayer.push({
+  event: 'qualify_lead',
+  click_id: 'abc123',
+  cuft_tracked: true,
+  cuft_source: 'webhook_replay',
+  cuft_replayed: true
+});
+```
+
+5. **Server marks events as replayed** (sets `replayed_at` timestamp).
+
+### Design Decisions
+
+- Events replay once only — marked after push.
+- `cuft_replayed: true` lets GTM distinguish real-time from queued events.
+- `cuft_source: 'webhook_replay'` distinguishes from form-triggered events.
+- No extra overhead on normal pageviews — AJAX only fires when click_id cookie exists, returns empty if no pending events.
+- No PHP sessions — cookie-based only (consistent with session removal fix).
+- Pending events expire after 30 days (cleanup via existing DB optimizer cron).
+
+### DB Change
+
+Add `replayed_at` (nullable datetime) column to the existing click events table. Pending = `replayed_at IS NULL` for webhook-originated events.
+
+## 6. Dual-Fire Deprecation Strategy
+
+### The Breaking Change
+
+Current `generate_lead` means "email + phone + click_id." After this change, `generate_lead` means "any form with email" and `qualify_lead` takes over the strict meaning.
+
+### Transition (1 Version)
+
+During the transition version, when a form submission meets the strict criteria (email + phone + click_id), the plugin fires:
+
+1. `form_submit` — always
+2. `generate_lead` — new broad meaning (has email)
+3. `qualify_lead` — new name for strict logic
+4. `generate_lead` (duplicate) — with `cuft_deprecated: true` and the old strict payload
+
+```javascript
+dataLayer.push({
+  event: 'generate_lead',
+  cuft_tracked: true,
+  cuft_deprecated: true,
+  cuft_migrate_to: 'qualify_lead',
+  // ... old strict payload
+});
+```
+
+### Console Warning
+
+When `cuft_console_logging` is enabled:
+
+```
+[CUFT] "generate_lead" with strict criteria is deprecated. Update your GTM trigger to use "qualify_lead" instead.
+```
+
+### Next Version
+
+Remove the dual-fire. `generate_lead` only fires with the new broad meaning.

--- a/includes/ajax/class-cuft-event-recorder.php
+++ b/includes/ajax/class-cuft-event-recorder.php
@@ -75,6 +75,7 @@ class CUFT_Event_Recorder {
             // Sanitize and validate inputs
             $click_id = isset( $_POST['click_id'] ) ? sanitize_text_field( $_POST['click_id'] ) : '';
             $event_type = isset( $_POST['event_type'] ) ? sanitize_text_field( $_POST['event_type'] ) : '';
+            $ga_client_id = isset( $_POST['ga_client_id'] ) ? sanitize_text_field( $_POST['ga_client_id'] ) : '';
 
             // Validate click_id
             if ( empty( $click_id ) ) {
@@ -105,6 +106,19 @@ class CUFT_Event_Recorder {
             $result = CUFT_Click_Tracker::add_event( $click_id, $event_type );
 
             if ( $result ) {
+                // Store ga_client_id if provided (for Measurement Protocol)
+                if ( ! empty( $ga_client_id ) ) {
+                    global $wpdb;
+                    $table_name = $wpdb->prefix . 'cuft_click_tracking';
+                    $wpdb->update(
+                        $table_name,
+                        array( 'ga_client_id' => sanitize_text_field( $ga_client_id ) ),
+                        array( 'click_id' => sanitize_text_field( $click_id ) ),
+                        array( '%s' ),
+                        array( '%s' )
+                    );
+                }
+
                 // Get updated event count
                 $events = CUFT_Click_Tracker::get_events( $click_id );
                 $event_count = is_array( $events ) ? count( $events ) : 0;

--- a/includes/ajax/class-cuft-event-recorder.php
+++ b/includes/ajax/class-cuft-event-recorder.php
@@ -23,6 +23,12 @@ class CUFT_Event_Recorder {
         'email_click',
         'form_submit',
         'generate_lead',
+        'qualify_lead',
+        'disqualify_lead',
+        'working_lead',
+        'close_convert_lead',
+        'close_unconvert_lead',
+        'score_updated',
     );
 
     /**

--- a/includes/ajax/class-cuft-event-recorder.php
+++ b/includes/ajax/class-cuft-event-recorder.php
@@ -76,6 +76,9 @@ class CUFT_Event_Recorder {
             $click_id = isset( $_POST['click_id'] ) ? sanitize_text_field( $_POST['click_id'] ) : '';
             $event_type = isset( $_POST['event_type'] ) ? sanitize_text_field( $_POST['event_type'] ) : '';
             $ga_client_id = isset( $_POST['ga_client_id'] ) ? sanitize_text_field( $_POST['ga_client_id'] ) : '';
+            if ( ! empty( $ga_client_id ) && ! preg_match( '/^\d+\.\d+$/', $ga_client_id ) ) {
+                $ga_client_id = ''; // Invalid format — discard
+            }
 
             // Validate click_id
             if ( empty( $click_id ) ) {

--- a/includes/ajax/class-cuft-event-replay.php
+++ b/includes/ajax/class-cuft-event-replay.php
@@ -108,10 +108,74 @@ class CUFT_Event_Replay {
     }
 
     /**
+     * Atomically fetch and mark pending webhook events for a given click_id.
+     *
+     * Uses a database transaction with SELECT ... FOR UPDATE to prevent race
+     * conditions where concurrent requests could replay the same events twice.
+     *
+     * @param string $click_id Click identifier.
+     * @return array Pending event objects (already marked as replayed in DB).
+     */
+    public static function get_and_mark_pending_events( string $click_id ): array {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $wpdb->query( 'START TRANSACTION' );
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s FOR UPDATE",
+            sanitize_text_field( $click_id )
+        ) );
+
+        if ( ! $row || empty( $row->events ) ) {
+            $wpdb->query( 'COMMIT' );
+            return array();
+        }
+
+        $events = json_decode( $row->events, true );
+        if ( ! is_array( $events ) ) {
+            $wpdb->query( 'COMMIT' );
+            return array();
+        }
+
+        $pending = array();
+        $updated = false;
+
+        foreach ( $events as &$event ) {
+            if ( ! empty( $event['source'] ) && 'webhook' === $event['source'] && ( ! isset( $event['replayed_at'] ) || null === $event['replayed_at'] ) ) {
+                $pending[]             = $event;
+                $event['replayed_at']  = current_time( 'mysql' );
+                $updated               = true;
+            }
+        }
+        unset( $event );
+
+        if ( $updated ) {
+            $wpdb->update(
+                $table,
+                array( 'events' => wp_json_encode( $events ) ),
+                array( 'click_id' => sanitize_text_field( $click_id ) ),
+                array( '%s' ),
+                array( '%s' )
+            );
+        }
+
+        $wpdb->query( 'COMMIT' );
+
+        return $pending;
+    }
+
+    /**
      * AJAX handler: return pending events and mark them replayed atomically.
      */
     public function ajax_get_pending(): void {
-        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- public endpoint keyed by click_id cookie
+        // Verify nonce.
+        $nonce = isset( $_GET['nonce'] ) ? sanitize_text_field( wp_unslash( $_GET['nonce'] ) ) : '';
+        if ( ! wp_verify_nonce( $nonce, 'cuft-event-recorder' ) ) {
+            wp_send_json_error( array( 'message' => 'Invalid nonce' ), 403 );
+            return;
+        }
+
         $click_id = isset( $_GET['click_id'] ) ? sanitize_text_field( wp_unslash( $_GET['click_id'] ) ) : '';
 
         if ( empty( $click_id ) ) {
@@ -119,11 +183,8 @@ class CUFT_Event_Replay {
             return;
         }
 
-        $pending = self::get_pending_events( $click_id );
-
-        if ( ! empty( $pending ) ) {
-            self::mark_events_replayed( $click_id );
-        }
+        // Atomically get and mark pending events (prevents race condition).
+        $pending = self::get_and_mark_pending_events( $click_id );
 
         wp_send_json_success( array( 'events' => $pending ) );
     }

--- a/includes/ajax/class-cuft-event-replay.php
+++ b/includes/ajax/class-cuft-event-replay.php
@@ -1,0 +1,130 @@
+<?php
+/**
+ * AJAX handler for client-side event replay.
+ *
+ * Webhook-originated lifecycle events (qualify_lead, etc.) are stored with
+ * source=webhook and replayed_at=null. On the next pageview the browser JS
+ * calls this endpoint, receives the pending events, pushes them into the
+ * dataLayer, and the server marks them as replayed so they fire only once.
+ *
+ * @package Choice_Universal_Form_Tracker
+ * @since   3.22.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Event_Replay {
+
+    /**
+     * Register AJAX actions.
+     */
+    public function __construct() {
+        add_action( 'wp_ajax_cuft_get_pending_events', array( $this, 'ajax_get_pending' ) );
+        add_action( 'wp_ajax_nopriv_cuft_get_pending_events', array( $this, 'ajax_get_pending' ) );
+    }
+
+    /**
+     * Return unreplayed webhook events for a given click_id.
+     *
+     * @param string $click_id Click identifier.
+     * @return array Pending event objects.
+     */
+    public static function get_pending_events( string $click_id ): array {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s",
+            sanitize_text_field( $click_id )
+        ) );
+
+        if ( ! $row || empty( $row->events ) ) {
+            return array();
+        }
+
+        $events = json_decode( $row->events, true );
+        if ( ! is_array( $events ) ) {
+            return array();
+        }
+
+        $pending = array();
+        foreach ( $events as $event ) {
+            if (
+                ! empty( $event['source'] ) &&
+                'webhook' === $event['source'] &&
+                ( ! isset( $event['replayed_at'] ) || null === $event['replayed_at'] )
+            ) {
+                $pending[] = $event;
+            }
+        }
+
+        return $pending;
+    }
+
+    /**
+     * Mark all unreplayed webhook events as replayed for a given click_id.
+     *
+     * @param string $click_id Click identifier.
+     */
+    public static function mark_events_replayed( string $click_id ): void {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s",
+            sanitize_text_field( $click_id )
+        ) );
+
+        if ( ! $row || empty( $row->events ) ) {
+            return;
+        }
+
+        $events  = json_decode( $row->events, true );
+        $updated = false;
+
+        foreach ( $events as &$event ) {
+            if (
+                ! empty( $event['source'] ) &&
+                'webhook' === $event['source'] &&
+                ( ! isset( $event['replayed_at'] ) || null === $event['replayed_at'] )
+            ) {
+                $event['replayed_at'] = current_time( 'mysql' );
+                $updated              = true;
+            }
+        }
+        unset( $event );
+
+        if ( $updated ) {
+            $wpdb->update(
+                $table,
+                array( 'events' => wp_json_encode( $events ) ),
+                array( 'click_id' => sanitize_text_field( $click_id ) ),
+                array( '%s' ),
+                array( '%s' )
+            );
+        }
+    }
+
+    /**
+     * AJAX handler: return pending events and mark them replayed atomically.
+     */
+    public function ajax_get_pending(): void {
+        // phpcs:ignore WordPress.Security.NonceVerification.Recommended -- public endpoint keyed by click_id cookie
+        $click_id = isset( $_GET['click_id'] ) ? sanitize_text_field( wp_unslash( $_GET['click_id'] ) ) : '';
+
+        if ( empty( $click_id ) ) {
+            wp_send_json_success( array( 'events' => array() ) );
+            return;
+        }
+
+        $pending = self::get_pending_events( $click_id );
+
+        if ( ! empty( $pending ) ) {
+            self::mark_events_replayed( $click_id );
+        }
+
+        wp_send_json_success( array( 'events' => $pending ) );
+    }
+}

--- a/includes/class-cuft-admin.php
+++ b/includes/class-cuft-admin.php
@@ -321,7 +321,7 @@ class CUFT_Admin {
                                         <?php endif; ?>
                                     </p>
                                 <?php else: ?>
-                                    <p style="margin: 0 0 8px; color: #a00;">&#9679; Not registered &mdash; define <code>CUFT_REGISTER_SECRET</code> in wp-config.php then click Register.</p>
+                                    <p style="margin: 0 0 8px; color: #a00;">&#9679; Not registered &mdash; set the Registration Secret below (or define <code>CUFT_REGISTER_SECRET</code> in wp-config.php) then click Register.</p>
                                 <?php endif; ?>
                                 <button type="button" id="cuft-register-site" class="button button-secondary">
                                     <?php echo $is_registered ? 'Re-register Site' : 'Register Site'; ?>
@@ -344,6 +344,47 @@ class CUFT_Admin {
                         </td>
                     </tr>
                 </table>
+
+                <!-- API Credentials Section -->
+                <div style="background: #fff; border: 1px solid #ccd0d4; border-radius: 6px; padding: 20px; margin-bottom: 20px;">
+                    <h3 style="margin: 0 0 15px; color: #23282d;">API Credentials</h3>
+                    <?php $register_secret_override = defined( 'CUFT_REGISTER_SECRET' ); ?>
+                    <table class="form-table">
+                        <tr>
+                            <th scope="row"><label for="cuft_register_secret">Registration Secret</label></th>
+                            <td>
+                                <?php if ( $register_secret_override ) : ?>
+                                    <input type="text" value="••••••••" disabled class="regular-text" />
+                                    <p class="description">Overridden by <code>CUFT_REGISTER_SECRET</code> in wp-config.php</p>
+                                <?php else : ?>
+                                    <input type="password" id="cuft_register_secret" name="cuft_register_secret"
+                                        value="<?php echo esc_attr( get_option( 'cuft_register_secret', '' ) ); ?>"
+                                        class="regular-text" autocomplete="off" />
+                                    <p class="description">Authenticates with the validator service.</p>
+                                <?php endif; ?>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="cuft_measurement_id">GA4 Measurement ID</label></th>
+                            <td>
+                                <input type="text" id="cuft_measurement_id" name="cuft_measurement_id"
+                                    value="<?php echo esc_attr( get_option( 'cuft_measurement_id', '' ) ); ?>"
+                                    class="regular-text" placeholder="G-XXXXXXXXXX" />
+                                <p class="description">Required for server-side Measurement Protocol events.</p>
+                            </td>
+                        </tr>
+                        <tr>
+                            <th scope="row"><label for="cuft_measurement_api_secret">GA4 API Secret</label></th>
+                            <td>
+                                <input type="password" id="cuft_measurement_api_secret" name="cuft_measurement_api_secret"
+                                    value="<?php echo esc_attr( get_option( 'cuft_measurement_api_secret', '' ) ); ?>"
+                                    class="regular-text" autocomplete="off" />
+                                <p class="description">Found in GA4 Admin > Data Streams > Measurement Protocol API secrets.</p>
+                            </td>
+                        </tr>
+                    </table>
+                </div>
+
                 <?php submit_button( 'Save Settings', 'primary', 'cuft_save' ); ?>
             </form>
         </div>
@@ -568,6 +609,20 @@ class CUFT_Admin {
             } else {
                 // If sGTM is disabled, clear the validation
                 update_option( 'cuft_sgtm_validated', false );
+            }
+
+            // API Credentials
+            if ( isset( $_POST['cuft_register_secret'] ) && ! defined( 'CUFT_REGISTER_SECRET' ) ) {
+                update_option( 'cuft_register_secret', sanitize_text_field( wp_unslash( $_POST['cuft_register_secret'] ) ) );
+            }
+            if ( isset( $_POST['cuft_measurement_id'] ) ) {
+                $measurement_id = sanitize_text_field( wp_unslash( $_POST['cuft_measurement_id'] ) );
+                if ( empty( $measurement_id ) || preg_match( '/^G-[A-Z0-9]+$/', $measurement_id ) ) {
+                    update_option( 'cuft_measurement_id', $measurement_id );
+                }
+            }
+            if ( isset( $_POST['cuft_measurement_api_secret'] ) ) {
+                update_option( 'cuft_measurement_api_secret', sanitize_text_field( wp_unslash( $_POST['cuft_measurement_api_secret'] ) ) );
             }
 
             add_settings_error( 'cuft_messages', 'cuft_message', 'Settings saved!', 'updated' );

--- a/includes/class-cuft-admin.php
+++ b/includes/class-cuft-admin.php
@@ -358,9 +358,9 @@ class CUFT_Admin {
                                     <p class="description">Overridden by <code>CUFT_REGISTER_SECRET</code> in wp-config.php</p>
                                 <?php else : ?>
                                     <input type="password" id="cuft_register_secret" name="cuft_register_secret"
-                                        value="<?php echo esc_attr( get_option( 'cuft_register_secret', '' ) ); ?>"
-                                        class="regular-text" autocomplete="off" />
-                                    <p class="description">Authenticates with the validator service.</p>
+                                        value="" class="regular-text" autocomplete="off"
+                                        placeholder="<?php echo get_option( 'cuft_register_secret', '' ) ? '••••••••' : ''; ?>" />
+                                    <p class="description">Authenticates with the validator service. Leave blank to keep current value.</p>
                                 <?php endif; ?>
                             </td>
                         </tr>
@@ -377,9 +377,9 @@ class CUFT_Admin {
                             <th scope="row"><label for="cuft_measurement_api_secret">GA4 API Secret</label></th>
                             <td>
                                 <input type="password" id="cuft_measurement_api_secret" name="cuft_measurement_api_secret"
-                                    value="<?php echo esc_attr( get_option( 'cuft_measurement_api_secret', '' ) ); ?>"
-                                    class="regular-text" autocomplete="off" />
-                                <p class="description">Found in GA4 Admin > Data Streams > Measurement Protocol API secrets.</p>
+                                    value="" class="regular-text" autocomplete="off"
+                                    placeholder="<?php echo get_option( 'cuft_measurement_api_secret', '' ) ? '••••••••' : ''; ?>" />
+                                <p class="description">Found in GA4 Admin > Data Streams > Measurement Protocol API secrets. Leave blank to keep current value.</p>
                             </td>
                         </tr>
                     </table>
@@ -613,7 +613,10 @@ class CUFT_Admin {
 
             // API Credentials
             if ( isset( $_POST['cuft_register_secret'] ) && ! defined( 'CUFT_REGISTER_SECRET' ) ) {
-                update_option( 'cuft_register_secret', sanitize_text_field( wp_unslash( $_POST['cuft_register_secret'] ) ) );
+                $secret = sanitize_text_field( wp_unslash( $_POST['cuft_register_secret'] ) );
+                if ( ! empty( $secret ) ) {
+                    update_option( 'cuft_register_secret', CUFT_Utils::encrypt_secret( $secret ) );
+                }
             }
             if ( isset( $_POST['cuft_measurement_id'] ) ) {
                 $measurement_id = sanitize_text_field( wp_unslash( $_POST['cuft_measurement_id'] ) );
@@ -622,7 +625,10 @@ class CUFT_Admin {
                 }
             }
             if ( isset( $_POST['cuft_measurement_api_secret'] ) ) {
-                update_option( 'cuft_measurement_api_secret', sanitize_text_field( wp_unslash( $_POST['cuft_measurement_api_secret'] ) ) );
+                $secret = sanitize_text_field( wp_unslash( $_POST['cuft_measurement_api_secret'] ) );
+                if ( ! empty( $secret ) ) {
+                    update_option( 'cuft_measurement_api_secret', CUFT_Utils::encrypt_secret( $secret ) );
+                }
             }
 
             add_settings_error( 'cuft_messages', 'cuft_message', 'Settings saved!', 'updated' );

--- a/includes/class-cuft-admin.php
+++ b/includes/class-cuft-admin.php
@@ -1798,7 +1798,11 @@ class CUFT_Admin {
                         <option value="email_click" <?php selected( $filter_event_type, 'email_click' ); ?>>Email Click</option>
                         <option value="form_submit" <?php selected( $filter_event_type, 'form_submit' ); ?>>Form Submit</option>
                         <option value="generate_lead" <?php selected( $filter_event_type, 'generate_lead' ); ?>>Generate Lead</option>
-                        <option value="status_qualified" <?php selected( $filter_event_type, 'status_qualified' ); ?>>Status Qualified</option>
+                        <option value="qualify_lead" <?php selected( $filter_event_type, 'qualify_lead' ); ?>>Qualify Lead</option>
+                        <option value="disqualify_lead" <?php selected( $filter_event_type, 'disqualify_lead' ); ?>>Disqualify Lead</option>
+                        <option value="working_lead" <?php selected( $filter_event_type, 'working_lead' ); ?>>Working Lead</option>
+                        <option value="close_convert_lead" <?php selected( $filter_event_type, 'close_convert_lead' ); ?>>Close Convert Lead</option>
+                        <option value="close_unconvert_lead" <?php selected( $filter_event_type, 'close_unconvert_lead' ); ?>>Close Unconvert Lead</option>
                         <option value="score_updated" <?php selected( $filter_event_type, 'score_updated' ); ?>>Score Updated</option>
                     </select>
                 </div>
@@ -1948,7 +1952,11 @@ class CUFT_Admin {
                                                 'email_click' => '#8b5cf6',
                                                 'form_submit' => '#10b981',
                                                 'generate_lead' => '#f59e0b',
-                                                'status_qualified' => '#ef4444',
+                                                'qualify_lead' => '#10b981',
+                                                'disqualify_lead' => '#ef4444',
+                                                'working_lead' => '#f59e0b',
+                                                'close_convert_lead' => '#059669',
+                                                'close_unconvert_lead' => '#6b7280',
                                                 'score_updated' => '#06b6d4'
                                             );
                                             $badge_color = isset( $badge_colors[ $event_type ] ) ? $badge_colors[ $event_type ] : '#6b7280';

--- a/includes/class-cuft-click-integration.php
+++ b/includes/class-cuft-click-integration.php
@@ -36,16 +36,6 @@ class CUFT_Click_Integration {
      * Initialize hooks
      */
     public function init_hooks() {
-        // Start the session early for frontend requests so the stored click ID
-        // is accessible via $_SESSION on page visits that don't have a click param in the URL.
-        // This ensures window.cuftClickData.click_id is populated on the form page
-        // even when the user landed on a different page with the gclid.
-        if ( ! is_admin() && ! wp_doing_ajax() && ! wp_doing_cron() ) {
-            if ( ! session_id() ) {
-                session_start();
-            }
-        }
-
         // Capture click IDs on page load
         add_action( 'wp', array( $this, 'capture_click_ids' ) );
 
@@ -104,13 +94,18 @@ class CUFT_Click_Integration {
         // Track the click
         $result = CUFT_Click_Tracker::track_click( $click_id, $tracking_data );
         
-        // Store click ID in session for form submissions
+        // Store click ID in cookie for form submissions
         if ( $result !== false ) {
-            if ( ! session_id() ) {
-                session_start();
-            }
-            $_SESSION['cuft_click_id'] = $click_id;
-            
+            setcookie( 'cuft_click_id', $click_id, array(
+                'expires'  => time() + ( 30 * DAY_IN_SECONDS ),
+                'path'     => COOKIEPATH,
+                'domain'   => COOKIE_DOMAIN,
+                'secure'   => is_ssl(),
+                'httponly'  => false, // Read by client-side JS for event replay
+                'samesite' => 'Lax',
+            ) );
+            $_COOKIE['cuft_click_id'] = $click_id; // Make available in current request
+
             // Log the tracking
             if ( class_exists( 'CUFT_Logger' ) ) {
                 CUFT_Logger::log( 'Click ID captured: ' . $click_id, 'info', array(
@@ -159,14 +154,8 @@ class CUFT_Click_Integration {
         $ip_hash = '';
         $platform = '';
 
-        // Session was started in init_hooks() for frontend requests; start it here
-        // as a fallback for any edge case where init_hooks() didn't run first.
-        if ( ! session_id() ) {
-            session_start();
-        }
-
-        if ( isset( $_SESSION['cuft_click_id'] ) ) {
-            $click_id = $_SESSION['cuft_click_id'];
+        if ( isset( $_COOKIE['cuft_click_id'] ) ) {
+            $click_id = sanitize_text_field( $_COOKIE['cuft_click_id'] );
 
             // Fetch additional tracking data from database
             if ( ! empty( $click_id ) && class_exists( 'CUFT_Click_Tracker' ) ) {
@@ -188,24 +177,24 @@ class CUFT_Click_Integration {
     }
     
     /**
-     * Get current click ID from session
+     * Get current click ID from cookie
      */
     public static function get_current_click_id() {
-        if ( ! session_id() ) {
-            session_start();
-        }
-        
-        return isset( $_SESSION['cuft_click_id'] ) ? $_SESSION['cuft_click_id'] : '';
+        return isset( $_COOKIE['cuft_click_id'] ) ? sanitize_text_field( $_COOKIE['cuft_click_id'] ) : '';
     }
-    
+
     /**
-     * Clear current click ID from session
+     * Clear current click ID
      */
     public static function clear_current_click_id() {
-        if ( ! session_id() ) {
-            session_start();
-        }
-        
-        unset( $_SESSION['cuft_click_id'] );
+        setcookie( 'cuft_click_id', '', array(
+            'expires'  => time() - 3600,
+            'path'     => COOKIEPATH,
+            'domain'   => COOKIE_DOMAIN,
+            'secure'   => is_ssl(),
+            'httponly'  => false,
+            'samesite' => 'Lax',
+        ) );
+        unset( $_COOKIE['cuft_click_id'] );
     }
 }

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -232,7 +232,7 @@ class CUFT_Click_Tracker {
         if ( empty( $update_data ) && $status ) {
             try {
                 if ( in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
-                    self::add_event( $click_id, $status );
+                    self::add_event( $click_id, $status, 'webhook' );
 
                     // Fire Measurement Protocol for webhook-driven lifecycle events
                     $ga_client_id = $current_record ? $current_record->ga_client_id : '';
@@ -266,7 +266,7 @@ class CUFT_Click_Tracker {
             try {
                 // Record lifecycle status event
                 if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
-                    self::add_event( $click_id, $status );
+                    self::add_event( $click_id, $status, 'webhook' );
 
                     // Fire Measurement Protocol for webhook-driven lifecycle events
                     $ga_client_id = $current_record ? $current_record->ga_client_id : '';
@@ -277,12 +277,12 @@ class CUFT_Click_Tracker {
                     ) );
                 } elseif ( $qualified === 1 || $qualified === '1' ) {
                     // Backward compatibility: qualified=1 maps to qualify_lead
-                    self::add_event( $click_id, 'qualify_lead' );
+                    self::add_event( $click_id, 'qualify_lead', 'webhook' );
                 }
 
                 // Record score_updated event if score increased
                 if ( $score !== null && $score > $old_score ) {
-                    self::add_event( $click_id, 'score_updated' );
+                    self::add_event( $click_id, 'score_updated', 'webhook' );
                 }
             } catch ( Exception $e ) {
                 if ( class_exists( 'CUFT_Logger' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -893,11 +893,13 @@ class CUFT_Click_Tracker {
     /**
      * Add event to click tracking record
      *
-     * @param string $click_id Unique click identifier
-     * @param string $event_type Event type (phone_click, email_click, form_submit, generate_lead, status_update)
+     * @param string      $click_id   Unique click identifier.
+     * @param string      $event_type Event type (phone_click, email_click, form_submit, generate_lead, etc.).
+     * @param string|null $source     Optional origin tag (e.g. 'webhook'). When set, the event also
+     *                                gets a `replayed_at` field (initially null) for client-side replay.
      * @return bool Success status
      */
-    public static function add_event( $click_id, $event_type ) {
+    public static function add_event( $click_id, $event_type, $source = null ) {
         global $wpdb;
 
         if ( empty( $click_id ) || empty( $event_type ) ) {
@@ -974,10 +976,15 @@ class CUFT_Click_Tracker {
 
             // If event type doesn't exist, append it
             if ( ! $event_exists ) {
-                $events[] = array(
-                    'event' => $event_type,
-                    'timestamp' => $new_timestamp
+                $new_event = array(
+                    'event'     => $event_type,
+                    'timestamp' => $new_timestamp,
                 );
+                if ( $source ) {
+                    $new_event['source']      = $source;
+                    $new_event['replayed_at'] = null;
+                }
+                $events[] = $new_event;
             }
 
             // FIFO cleanup: Limit to 100 events (remove oldest if exceeded)

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -759,6 +759,11 @@ class CUFT_Click_Tracker {
             'form_submit' => 'Form Submit',
             'generate_lead' => 'Qualified Lead',
             'status_qualified' => 'Status Qualified',
+            'qualify_lead' => 'Qualify Lead',
+            'disqualify_lead' => 'Disqualify Lead',
+            'working_lead' => 'Working Lead',
+            'close_convert_lead' => 'Close Convert Lead',
+            'close_unconvert_lead' => 'Close Unconvert Lead',
             'score_updated' => 'Score Updated'
         );
 
@@ -847,8 +852,13 @@ class CUFT_Click_Tracker {
             'email_click',
             'form_submit',
             'generate_lead',
-            'status_qualified',  // Webhook event
-            'score_updated'      // Webhook event
+            'qualify_lead',
+            'disqualify_lead',
+            'working_lead',
+            'close_convert_lead',
+            'close_unconvert_lead',
+            'score_updated',
+            'status_qualified',
         );
         if ( ! in_array( $event_type, $valid_events ) ) {
             if ( class_exists( 'CUFT_Logger' ) ) {

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -838,9 +838,9 @@ class CUFT_Click_Tracker {
             'phone_click' => 'Phone Click',
             'email_click' => 'Email Click',
             'form_submit' => 'Form Submit',
-            'generate_lead' => 'Qualified Lead',
+            'generate_lead' => 'Lead Generated',
             'status_qualified' => 'Status Qualified', // Retained for display of legacy events
-            'qualify_lead' => 'Qualify Lead',
+            'qualify_lead' => 'Qualified Lead',
             'disqualify_lead' => 'Disqualify Lead',
             'working_lead' => 'Working Lead',
             'close_convert_lead' => 'Close Convert Lead',
@@ -863,7 +863,7 @@ class CUFT_Click_Tracker {
      */
     private static function calculate_conversion_value( $event_type, $score, $lead_value ) {
         // Only qualified leads get a value
-        if ( $event_type === 'generate_lead' ) {
+        if ( $event_type === 'qualify_lead' ) {
             return round( ( $lead_value * $score ) / 10, 2 );
         }
 

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -181,9 +181,24 @@ class CUFT_Click_Tracker {
     }
     
     /**
+     * Get valid webhook status values for lead lifecycle events
+     *
+     * @return array List of valid status strings.
+     */
+    public static function get_valid_webhook_statuses() {
+        return array(
+            'qualify_lead',
+            'disqualify_lead',
+            'working_lead',
+            'close_convert_lead',
+            'close_unconvert_lead',
+        );
+    }
+
+    /**
      * Update qualified status and score
      */
-    public static function update_click_status( $click_id, $qualified = null, $score = null ) {
+    public static function update_click_status( $click_id, $qualified = null, $score = null, $status = null ) {
         global $wpdb;
 
         if ( empty( $click_id ) ) {
@@ -213,7 +228,21 @@ class CUFT_Click_Tracker {
             $update_format[] = '%d';
         }
 
-        if ( empty( $update_data ) ) {
+        // If only status provided (no qualified/score changes), still record the event
+        if ( empty( $update_data ) && $status ) {
+            try {
+                if ( in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+                    self::add_event( $click_id, $status );
+                }
+            } catch ( Exception $e ) {
+                if ( class_exists( 'CUFT_Logger' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+                    CUFT_Logger::log( 'error', 'Failed to record webhook event: ' . $e->getMessage() );
+                }
+            }
+            return true;
+        }
+
+        if ( empty( $update_data ) && ! $status ) {
             return false;
         }
 
@@ -226,11 +255,13 @@ class CUFT_Click_Tracker {
         );
 
         if ( $result !== false ) {
-            // Record events for webhook updates (non-breaking, wrapped in try-catch)
             try {
-                // Record status_qualified event if qualified=1
-                if ( $qualified === 1 ) {
-                    self::add_event( $click_id, 'status_qualified' );
+                // Record lifecycle status event
+                if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+                    self::add_event( $click_id, $status );
+                } elseif ( $qualified === 1 || $qualified === '1' ) {
+                    // Backward compatibility: qualified=1 maps to qualify_lead
+                    self::add_event( $click_id, 'qualify_lead' );
                 }
 
                 // Record score_updated event if score increased
@@ -238,7 +269,6 @@ class CUFT_Click_Tracker {
                     self::add_event( $click_id, 'score_updated' );
                 }
             } catch ( Exception $e ) {
-                // Never break webhook functionality due to event recording failures
                 if ( class_exists( 'CUFT_Logger' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
                     CUFT_Logger::log( 'error', 'Failed to record webhook event: ' . $e->getMessage() );
                 }
@@ -491,6 +521,19 @@ class CUFT_Click_Tracker {
         // Get optional parameters
         $qualified = isset( $_GET['qualified'] ) ? (int) $_GET['qualified'] : null;
         $score = isset( $_GET['score'] ) ? (int) $_GET['score'] : null;
+        $status = isset( $_GET['status'] ) ? sanitize_text_field( wp_unslash( $_GET['status'] ) ) : null;
+
+        // Validate status if provided
+        if ( $status && ! in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+            wp_send_json_error( array(
+                'message' => 'Invalid status value. Valid values: ' . implode( ', ', self::get_valid_webhook_statuses() ),
+            ), 400 );
+        }
+
+        // Status=qualify_lead implies qualified=1
+        if ( 'qualify_lead' === $status && null === $qualified ) {
+            $qualified = 1;
+        }
 
         // Validate score range
         if ( $score !== null && ( $score < 0 || $score > 10 ) ) {
@@ -498,14 +541,15 @@ class CUFT_Click_Tracker {
         }
 
         // Update the record
-        $result = self::update_click_status( $click_id, $qualified, $score );
+        $result = self::update_click_status( $click_id, $qualified, $score, $status );
 
         if ( $result !== false ) {
             wp_send_json_success( array(
                 'message' => 'Click status updated successfully',
                 'click_id' => $click_id,
                 'qualified' => $qualified,
-                'score' => $score
+                'score' => $score,
+                'status' => $status,
             ) );
         } else {
             wp_send_json_error( array( 'message' => 'Failed to update click status' ), 500 );

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -196,6 +196,35 @@ class CUFT_Click_Tracker {
     }
 
     /**
+     * Fire Measurement Protocol for webhook-driven lifecycle events
+     *
+     * @param string      $click_id       Unique click identifier.
+     * @param string|null $status         Lifecycle status value.
+     * @param object|null $current_record Current DB record for the click.
+     */
+    private static function fire_measurement_protocol( $click_id, $status, $current_record ) {
+        if ( ! $status || ! in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
+            return;
+        }
+
+        $ga_client_id = '';
+        if ( $current_record && ! empty( $current_record->ga_client_id ) ) {
+            $ga_client_id = $current_record->ga_client_id;
+        }
+
+        $platform = 'unknown';
+        if ( $current_record && ! empty( $current_record->platform ) ) {
+            $platform = $current_record->platform;
+        }
+
+        $mp = new CUFT_Measurement_Protocol();
+        $mp->send( $ga_client_id, $status, array(
+            'click_id'    => $click_id,
+            'lead_source' => $platform,
+        ) );
+    }
+
+    /**
      * Update qualified status and score
      */
     public static function update_click_status( $click_id, $qualified = null, $score = null, $status = null ) {
@@ -233,14 +262,7 @@ class CUFT_Click_Tracker {
             try {
                 if ( in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
                     self::add_event( $click_id, $status, 'webhook' );
-
-                    // Fire Measurement Protocol for webhook-driven lifecycle events
-                    $ga_client_id = $current_record ? $current_record->ga_client_id : '';
-                    $mp = new CUFT_Measurement_Protocol();
-                    $mp->send( $ga_client_id ?: '', $status, array(
-                        'click_id'    => $click_id,
-                        'lead_source' => $current_record ? ( isset( $current_record->platform ) ? $current_record->platform : 'unknown' ) : 'unknown',
-                    ) );
+                    self::fire_measurement_protocol( $click_id, $status, $current_record );
                 }
             } catch ( Exception $e ) {
                 if ( class_exists( 'CUFT_Logger' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -267,14 +289,7 @@ class CUFT_Click_Tracker {
                 // Record lifecycle status event
                 if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
                     self::add_event( $click_id, $status, 'webhook' );
-
-                    // Fire Measurement Protocol for webhook-driven lifecycle events
-                    $ga_client_id = $current_record ? $current_record->ga_client_id : '';
-                    $mp = new CUFT_Measurement_Protocol();
-                    $mp->send( $ga_client_id ?: '', $status, array(
-                        'click_id'    => $click_id,
-                        'lead_source' => $current_record ? ( isset( $current_record->platform ) ? $current_record->platform : 'unknown' ) : 'unknown',
-                    ) );
+                    self::fire_measurement_protocol( $click_id, $status, $current_record );
                 } elseif ( $qualified === 1 || $qualified === '1' ) {
                     // Backward compatibility: qualified=1 maps to qualify_lead
                     self::add_event( $click_id, 'qualify_lead', 'webhook' );
@@ -546,9 +561,15 @@ class CUFT_Click_Tracker {
             ), 400 );
         }
 
-        // Status=qualify_lead implies qualified=1
-        if ( 'qualify_lead' === $status && null === $qualified ) {
-            $qualified = 1;
+        // Status takes precedence over qualified parameter
+        if ( $status ) {
+            if ( 'qualify_lead' === $status ) {
+                // qualify_lead implies qualified=1
+                $qualified = 1;
+            } else {
+                // Other statuses: don't update qualified field
+                $qualified = null;
+            }
         }
 
         // Validate score range
@@ -818,7 +839,7 @@ class CUFT_Click_Tracker {
             'email_click' => 'Email Click',
             'form_submit' => 'Form Submit',
             'generate_lead' => 'Qualified Lead',
-            'status_qualified' => 'Status Qualified',
+            'status_qualified' => 'Status Qualified', // Retained for display of legacy events
             'qualify_lead' => 'Qualify Lead',
             'disqualify_lead' => 'Disqualify Lead',
             'working_lead' => 'Working Lead',
@@ -920,7 +941,7 @@ class CUFT_Click_Tracker {
             'close_convert_lead',
             'close_unconvert_lead',
             'score_updated',
-            'status_qualified',
+            'status_qualified', // Legacy: retained for backward compatibility with existing data
         );
         if ( ! in_array( $event_type, $valid_events ) ) {
             if ( class_exists( 'CUFT_Logger' ) ) {

--- a/includes/class-cuft-click-tracker.php
+++ b/includes/class-cuft-click-tracker.php
@@ -207,9 +207,9 @@ class CUFT_Click_Tracker {
 
         $table_name = $wpdb->prefix . self::$table_name;
 
-        // Get current record to check for score increase
+        // Get current record to check for score increase and MP firing
         $current_record = $wpdb->get_row( $wpdb->prepare(
-            "SELECT qualified, score FROM $table_name WHERE click_id = %s",
+            "SELECT qualified, score, platform, ga_client_id FROM $table_name WHERE click_id = %s",
             sanitize_text_field( $click_id )
         ) );
 
@@ -233,6 +233,14 @@ class CUFT_Click_Tracker {
             try {
                 if ( in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
                     self::add_event( $click_id, $status );
+
+                    // Fire Measurement Protocol for webhook-driven lifecycle events
+                    $ga_client_id = $current_record ? $current_record->ga_client_id : '';
+                    $mp = new CUFT_Measurement_Protocol();
+                    $mp->send( $ga_client_id ?: '', $status, array(
+                        'click_id'    => $click_id,
+                        'lead_source' => $current_record ? ( isset( $current_record->platform ) ? $current_record->platform : 'unknown' ) : 'unknown',
+                    ) );
                 }
             } catch ( Exception $e ) {
                 if ( class_exists( 'CUFT_Logger' ) && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
@@ -259,6 +267,14 @@ class CUFT_Click_Tracker {
                 // Record lifecycle status event
                 if ( $status && in_array( $status, self::get_valid_webhook_statuses(), true ) ) {
                     self::add_event( $click_id, $status );
+
+                    // Fire Measurement Protocol for webhook-driven lifecycle events
+                    $ga_client_id = $current_record ? $current_record->ga_client_id : '';
+                    $mp = new CUFT_Measurement_Protocol();
+                    $mp->send( $ga_client_id ?: '', $status, array(
+                        'click_id'    => $click_id,
+                        'lead_source' => $current_record ? ( isset( $current_record->platform ) ? $current_record->platform : 'unknown' ) : 'unknown',
+                    ) );
                 } elseif ( $qualified === 1 || $qualified === '1' ) {
                     // Backward compatibility: qualified=1 maps to qualify_lead
                     self::add_event( $click_id, 'qualify_lead' );

--- a/includes/class-cuft-db-migration.php
+++ b/includes/class-cuft-db-migration.php
@@ -13,7 +13,7 @@ class CUFT_DB_Migration {
     /**
      * Current database schema version
      */
-    const CURRENT_VERSION = '3.21.0';
+    const CURRENT_VERSION = '3.22.0';
 
     /**
      * Option name for storing database version
@@ -49,6 +49,15 @@ class CUFT_DB_Migration {
         // Run 3.21.0 migration for IP hash
         if ( version_compare( $current_version, '3.21.0', '<' ) ) {
             self::migrate_to_3_21_0();
+        }
+
+        // Run 3.22.0 migration for ga_client_id and replayed_at columns
+        if ( version_compare( $current_version, '3.22.0', '<' ) ) {
+            if ( class_exists( 'CUFT_Migration_3_22_0' ) ) {
+                if ( CUFT_Migration_3_22_0::needs_migration() ) {
+                    CUFT_Migration_3_22_0::up();
+                }
+            }
         }
 
         // Update version

--- a/includes/class-cuft-db-optimizer.php
+++ b/includes/class-cuft-db-optimizer.php
@@ -323,8 +323,8 @@ class CUFT_DB_Optimizer {
             return 0;
         }
 
-        $thirty_days_ago = gmdate( 'c', strtotime( '-30 days' ) );
-        $updated_count   = 0;
+        $cutoff        = strtotime( '-30 days' );
+        $updated_count = 0;
 
         foreach ( $clicks as $click ) {
             $events = json_decode( $click->events, true );
@@ -337,7 +337,7 @@ class CUFT_DB_Optimizer {
             foreach ( $events as &$event ) {
                 if ( ! empty( $event['source'] ) && 'webhook' === $event['source']
                     && ( ! isset( $event['replayed_at'] ) || null === $event['replayed_at'] )
-                    && isset( $event['timestamp'] ) && $event['timestamp'] < $thirty_days_ago ) {
+                    && isset( $event['timestamp'] ) && strtotime( $event['timestamp'] ) < $cutoff ) {
                     $event['replayed_at'] = 'expired';
                     $updated = true;
                 }

--- a/includes/class-cuft-db-optimizer.php
+++ b/includes/class-cuft-db-optimizer.php
@@ -28,6 +28,9 @@ class CUFT_DB_Optimizer {
     public static function init() {
         // Hook into WordPress admin init for optimization checks
         add_action('admin_init', array(__CLASS__, 'maybe_optimize_tables'));
+
+        // Hook stale pending event cleanup into the daily cron (S5 spec requirement)
+        add_action('cuft_daily_cleanup', array(__CLASS__, 'cleanup_stale_pending_events'));
     }
 
     /**
@@ -285,6 +288,79 @@ class CUFT_DB_Optimizer {
         );
 
         return (int) $deleted;
+    }
+
+    /**
+     * Expire stale pending webhook events older than 30 days
+     *
+     * Finds click records containing webhook events that have never been replayed
+     * (replayed_at is null) and whose timestamp is older than 30 days. Marks those
+     * events as 'expired' so the replay endpoint no longer returns them.
+     *
+     * @since 3.22.0
+     * @return int Number of click records updated
+     */
+    public static function cleanup_stale_pending_events() {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        // Check if table exists
+        $table_exists = $wpdb->get_var(
+            $wpdb->prepare( "SHOW TABLES LIKE %s", $table )
+        );
+
+        if ( ! $table_exists ) {
+            return 0;
+        }
+
+        // Find clicks with unreplayed webhook events
+        $clicks = $wpdb->get_results(
+            "SELECT click_id, events FROM {$table} WHERE events LIKE '%\"source\":\"webhook\"%' AND events LIKE '%\"replayed_at\":null%'"
+        );
+
+        if ( empty( $clicks ) ) {
+            return 0;
+        }
+
+        $thirty_days_ago = gmdate( 'c', strtotime( '-30 days' ) );
+        $updated_count   = 0;
+
+        foreach ( $clicks as $click ) {
+            $events = json_decode( $click->events, true );
+            if ( ! is_array( $events ) ) {
+                continue;
+            }
+
+            $updated = false;
+
+            foreach ( $events as &$event ) {
+                if ( ! empty( $event['source'] ) && 'webhook' === $event['source']
+                    && ( ! isset( $event['replayed_at'] ) || null === $event['replayed_at'] )
+                    && isset( $event['timestamp'] ) && $event['timestamp'] < $thirty_days_ago ) {
+                    $event['replayed_at'] = 'expired';
+                    $updated = true;
+                }
+            }
+            unset( $event );
+
+            if ( $updated ) {
+                $wpdb->update(
+                    $table,
+                    array( 'events' => wp_json_encode( $events ) ),
+                    array( 'click_id' => $click->click_id ),
+                    array( '%s' ),
+                    array( '%s' )
+                );
+                $updated_count++;
+            }
+        }
+
+        if ( $updated_count > 0 && defined( 'WP_DEBUG' ) && WP_DEBUG ) {
+            error_log( sprintf( 'CUFT DB Optimizer: Expired stale pending events in %d click records', $updated_count ) );
+        }
+
+        return $updated_count;
     }
 
     /**

--- a/includes/class-cuft-measurement-protocol.php
+++ b/includes/class-cuft-measurement-protocol.php
@@ -51,7 +51,7 @@ class CUFT_Measurement_Protocol {
         }
 
         $measurement_id = get_option( 'cuft_measurement_id', '' );
-        $api_secret     = get_option( 'cuft_measurement_api_secret', '' );
+        $api_secret     = CUFT_Utils::decrypt_secret( get_option( 'cuft_measurement_api_secret', '' ) );
 
         $url = add_query_arg( array(
             'measurement_id' => $measurement_id,

--- a/includes/class-cuft-measurement-protocol.php
+++ b/includes/class-cuft-measurement-protocol.php
@@ -1,0 +1,86 @@
+<?php
+// includes/class-cuft-measurement-protocol.php
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Measurement_Protocol {
+
+    const ENDPOINT = 'https://www.google-analytics.com/mp/collect';
+
+    public function is_configured(): bool {
+        return ! empty( get_option( 'cuft_measurement_id', '' ) )
+            && ! empty( get_option( 'cuft_measurement_api_secret', '' ) );
+    }
+
+    public function build_payload( string $client_id, string $event_name, array $event_params = array() ): array {
+        $lead_value    = get_option( 'cuft_lead_value', 100 );
+        $lead_currency = get_option( 'cuft_lead_currency', 'CAD' );
+
+        $params = array_merge( array(
+            'value'                => (float) $lead_value,
+            'currency'             => $lead_currency,
+            'engagement_time_msec' => 1,
+        ), $event_params );
+
+        return array(
+            'client_id' => $client_id,
+            'events'    => array(
+                array(
+                    'name'   => $event_name,
+                    'params' => $params,
+                ),
+            ),
+        );
+    }
+
+    public function send( string $client_id, string $event_name, array $event_params = array() ): bool {
+        if ( ! $this->is_configured() ) {
+            if ( class_exists( 'CUFT_Logger' ) ) {
+                CUFT_Logger::log( 'Measurement Protocol not configured — skipping event: ' . $event_name );
+            }
+            return false;
+        }
+
+        if ( empty( $client_id ) ) {
+            if ( class_exists( 'CUFT_Logger' ) ) {
+                CUFT_Logger::log( 'No ga_client_id available — skipping MP event: ' . $event_name );
+            }
+            return false;
+        }
+
+        $measurement_id = get_option( 'cuft_measurement_id', '' );
+        $api_secret     = get_option( 'cuft_measurement_api_secret', '' );
+
+        $url = add_query_arg( array(
+            'measurement_id' => $measurement_id,
+            'api_secret'     => $api_secret,
+        ), self::ENDPOINT );
+
+        $payload = $this->build_payload( $client_id, $event_name, $event_params );
+
+        $response = wp_remote_post( $url, array(
+            'headers' => array( 'Content-Type' => 'application/json' ),
+            'body'    => wp_json_encode( $payload ),
+            'timeout' => 5,
+        ) );
+
+        if ( is_wp_error( $response ) ) {
+            if ( class_exists( 'CUFT_Logger' ) ) {
+                CUFT_Logger::log( 'MP request failed for ' . $event_name . ': ' . $response->get_error_message() );
+            }
+            return false;
+        }
+
+        $code = wp_remote_retrieve_response_code( $response );
+        if ( $code < 200 || $code >= 300 ) {
+            if ( class_exists( 'CUFT_Logger' ) ) {
+                CUFT_Logger::log( 'MP request returned HTTP ' . $code . ' for ' . $event_name );
+            }
+            return false;
+        }
+
+        return true;
+    }
+}

--- a/includes/class-cuft-token-manager.php
+++ b/includes/class-cuft-token-manager.php
@@ -33,14 +33,14 @@ class CUFT_Token_Manager {
     }
 
     /**
-     * Secret used to authenticate /register requests.
-     * Must be defined as CUFT_REGISTER_SECRET in wp-config.php.
+     * Get the registration secret. wp-config.php constant takes precedence,
+     * then falls back to the DB option.
      */
-    private static function get_register_secret(): string {
+    public static function get_register_secret_value(): string {
         if ( defined( 'CUFT_REGISTER_SECRET' ) ) {
             return CUFT_REGISTER_SECRET;
         }
-        return '';
+        return get_option( 'cuft_register_secret', '' );
     }
 
     /**
@@ -48,11 +48,11 @@ class CUFT_Token_Manager {
      * Returns WP_Error on failure, or the token string on success.
      */
     public static function register_site(): string|WP_Error {
-        $secret = self::get_register_secret();
+        $secret = self::get_register_secret_value();
         if ( empty( $secret ) ) {
             return new WP_Error(
                 'cuft_no_secret',
-                'CUFT_REGISTER_SECRET is not defined in wp-config.php'
+                'Registration secret is not configured. Define CUFT_REGISTER_SECRET in wp-config.php or set it in Settings > Universal Form Tracker > API Credentials.'
             );
         }
 

--- a/includes/class-cuft-token-manager.php
+++ b/includes/class-cuft-token-manager.php
@@ -40,7 +40,7 @@ class CUFT_Token_Manager {
         if ( defined( 'CUFT_REGISTER_SECRET' ) ) {
             return CUFT_REGISTER_SECRET;
         }
-        return get_option( 'cuft_register_secret', '' );
+        return CUFT_Utils::decrypt_secret( get_option( 'cuft_register_secret', '' ) );
     }
 
     /**

--- a/includes/class-cuft-utils.php
+++ b/includes/class-cuft-utils.php
@@ -197,7 +197,7 @@ class CUFT_Utils {
                 }
 
                 // Validate event types
-                $valid_events = array( 'phone_click', 'email_click', 'form_submit', 'generate_lead', 'status_update' );
+                $valid_events = array( 'phone_click', 'email_click', 'form_submit', 'generate_lead', 'status_update', 'qualify_lead', 'disqualify_lead', 'working_lead', 'close_convert_lead', 'close_unconvert_lead', 'score_updated' );
                 if ( ! in_array( $event['event'], $valid_events ) ) {
                     return false;
                 }
@@ -235,11 +235,17 @@ class CUFT_Utils {
      */
     public static function get_event_display_name( $event_type ) {
         $display_names = array(
-            'phone_click' => 'Phone Click',
-            'email_click' => 'Email Click',
-            'form_submit' => 'Form Submit',
-            'generate_lead' => 'Generate Lead',
-            'status_update' => 'Status Update'
+            'phone_click'          => 'Phone Click',
+            'email_click'          => 'Email Click',
+            'form_submit'          => 'Form Submit',
+            'generate_lead'        => 'Generate Lead',
+            'qualify_lead'         => 'Qualify Lead',
+            'disqualify_lead'      => 'Disqualify Lead',
+            'working_lead'         => 'Working Lead',
+            'close_convert_lead'   => 'Close Convert Lead',
+            'close_unconvert_lead' => 'Close Unconvert Lead',
+            'score_updated'        => 'Score Updated',
+            'status_update'        => 'Status Update',
         );
 
         return isset( $display_names[ $event_type ] ) ? $display_names[ $event_type ] : $event_type;
@@ -253,11 +259,17 @@ class CUFT_Utils {
      */
     public static function get_event_icon( $event_type ) {
         $icons = array(
-            'phone_click' => '📞',
-            'email_click' => '📧',
-            'form_submit' => '📝',
-            'generate_lead' => '⭐',
-            'status_update' => '🔄'
+            'phone_click'          => '📞',
+            'email_click'          => '📧',
+            'form_submit'          => '📝',
+            'generate_lead'        => '🎯',
+            'qualify_lead'         => '⭐',
+            'disqualify_lead'      => '❌',
+            'working_lead'         => '📋',
+            'close_convert_lead'   => '✅',
+            'close_unconvert_lead' => '🚫',
+            'score_updated'        => '📊',
+            'status_update'        => '🔄',
         );
 
         return isset( $icons[ $event_type ] ) ? $icons[ $event_type ] : '●';

--- a/includes/class-cuft-utils.php
+++ b/includes/class-cuft-utils.php
@@ -276,6 +276,54 @@ class CUFT_Utils {
     }
 
     /**
+     * Encrypt a secret value using AES-256-CBC with AUTH_SALT.
+     *
+     * @param string $plaintext The secret to encrypt.
+     * @return string Base64-encoded ciphertext, or the original value on failure.
+     */
+    public static function encrypt_secret( string $plaintext ): string {
+        if ( empty( $plaintext ) ) {
+            return '';
+        }
+        $key = substr( hash( 'sha256', AUTH_SALT ), 0, 32 );
+        $iv  = openssl_random_pseudo_bytes( 16 );
+        $encrypted = openssl_encrypt( $plaintext, 'aes-256-cbc', $key, 0, $iv );
+        if ( false === $encrypted ) {
+            return $plaintext; // Fallback to plaintext if encryption fails
+        }
+        return base64_encode( $iv . $encrypted );
+    }
+
+    /**
+     * Decrypt a secret value previously encrypted with encrypt_secret().
+     *
+     * Gracefully handles plaintext values that were stored before encryption
+     * was introduced — if decryption fails the raw value is returned as-is.
+     *
+     * @param string $ciphertext The stored (possibly encrypted) value.
+     * @return string Decrypted plaintext.
+     */
+    public static function decrypt_secret( string $ciphertext ): string {
+        if ( empty( $ciphertext ) ) {
+            return '';
+        }
+        $key  = substr( hash( 'sha256', AUTH_SALT ), 0, 32 );
+        $data = base64_decode( $ciphertext, true );
+        if ( false === $data || strlen( $data ) < 17 ) {
+            // Not encrypted or too short — return as-is (handles migration from plaintext)
+            return $ciphertext;
+        }
+        $iv        = substr( $data, 0, 16 );
+        $encrypted = substr( $data, 16 );
+        $decrypted = openssl_decrypt( $encrypted, 'aes-256-cbc', $key, 0, $iv );
+        if ( false === $decrypted ) {
+            // Decryption failed — might be a plaintext value from before encryption was added
+            return $ciphertext;
+        }
+        return $decrypted;
+    }
+
+    /**
      * Debug log helper
      *
      * @param string $message Log message

--- a/includes/class-cuft-utils.php
+++ b/includes/class-cuft-utils.php
@@ -287,7 +287,7 @@ class CUFT_Utils {
         }
         $key = substr( hash( 'sha256', AUTH_SALT ), 0, 32 );
         $iv  = openssl_random_pseudo_bytes( 16 );
-        $encrypted = openssl_encrypt( $plaintext, 'aes-256-cbc', $key, 0, $iv );
+        $encrypted = openssl_encrypt( $plaintext, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
         if ( false === $encrypted ) {
             return $plaintext; // Fallback to plaintext if encryption fails
         }
@@ -315,7 +315,7 @@ class CUFT_Utils {
         }
         $iv        = substr( $data, 0, 16 );
         $encrypted = substr( $data, 16 );
-        $decrypted = openssl_decrypt( $encrypted, 'aes-256-cbc', $key, 0, $iv );
+        $decrypted = openssl_decrypt( $encrypted, 'aes-256-cbc', $key, OPENSSL_RAW_DATA, $iv );
         if ( false === $decrypted ) {
             // Decryption failed — might be a plaintext value from before encryption was added
             return $ciphertext;

--- a/includes/class-cuft-utm-tracker.php
+++ b/includes/class-cuft-utm-tracker.php
@@ -88,17 +88,9 @@ class CUFT_UTM_Tracker {
         }
         
         if ( ! empty( $tracking_data ) ) {
-            // Store in session (with cookie fallback)
-            if ( ! session_id() ) {
-                session_start();
-            }
-            $_SESSION['cuft_utm_data'] = $tracking_data;
-            $_SESSION['cuft_utm_timestamp'] = current_time( 'timestamp' );
-            
-            // Also store in cookie for persistence
             $this->store_utm_cookie( $tracking_data );
-            
-            CUFT_Logger::log( 'Tracking data stored for session', CUFT_Logger::DEBUG, $tracking_data );
+
+            CUFT_Logger::log( 'Tracking data stored in cookie', CUFT_Logger::DEBUG, $tracking_data );
         }
         
         wp_send_json_success();
@@ -114,13 +106,14 @@ class CUFT_UTM_Tracker {
         );
         
         // Store for 30 days
-        setcookie( 
-            'cuft_utm_data', 
-            wp_json_encode( $cookie_data ), 
-            time() + ( 30 * DAY_IN_SECONDS ), 
-            COOKIEPATH, 
-            COOKIE_DOMAIN 
-        );
+        setcookie( 'cuft_utm_data', wp_json_encode( $cookie_data ), array(
+            'expires'  => time() + ( 30 * DAY_IN_SECONDS ),
+            'path'     => COOKIEPATH,
+            'domain'   => COOKIE_DOMAIN,
+            'secure'   => is_ssl(),
+            'httponly'  => false, // Read by client-side JS
+            'samesite' => 'Lax',
+        ) );
     }
     
     /**
@@ -128,24 +121,17 @@ class CUFT_UTM_Tracker {
      */
     public static function get_utm_data() {
         $utm_data = array();
-        
-        // Try session first
-        if ( session_id() && isset( $_SESSION['cuft_utm_data'] ) ) {
-            $utm_data = $_SESSION['cuft_utm_data'];
-        } else {
-            // Fallback to cookie
-            if ( isset( $_COOKIE['cuft_utm_data'] ) ) {
-                $cookie_data = json_decode( stripslashes( $_COOKIE['cuft_utm_data'] ), true );
-                if ( is_array( $cookie_data ) && isset( $cookie_data['utm'] ) ) {
-                    // Check if cookie is not too old (30 days)
-                    $timestamp = isset( $cookie_data['timestamp'] ) ? $cookie_data['timestamp'] : 0;
-                    if ( ( current_time( 'timestamp' ) - $timestamp ) < ( 30 * DAY_IN_SECONDS ) ) {
-                        $utm_data = $cookie_data['utm'];
-                    }
+
+        if ( isset( $_COOKIE['cuft_utm_data'] ) ) {
+            $cookie_data = json_decode( stripslashes( $_COOKIE['cuft_utm_data'] ), true );
+            if ( is_array( $cookie_data ) && isset( $cookie_data['utm'] ) ) {
+                $timestamp = isset( $cookie_data['timestamp'] ) ? $cookie_data['timestamp'] : 0;
+                if ( ( current_time( 'timestamp' ) - $timestamp ) < ( 30 * DAY_IN_SECONDS ) ) {
+                    $utm_data = $cookie_data['utm'];
                 }
             }
         }
-        
+
         return $utm_data;
     }
     
@@ -161,11 +147,14 @@ class CUFT_UTM_Tracker {
      * Clear UTM data
      */
     public static function clear_utm_data() {
-        if ( session_id() ) {
-            unset( $_SESSION['cuft_utm_data'] );
-            unset( $_SESSION['cuft_utm_timestamp'] );
-        }
-        
-        setcookie( 'cuft_utm_data', '', time() - 3600, COOKIEPATH, COOKIE_DOMAIN );
+        setcookie( 'cuft_utm_data', '', array(
+            'expires'  => time() - 3600,
+            'path'     => COOKIEPATH,
+            'domain'   => COOKIE_DOMAIN,
+            'secure'   => is_ssl(),
+            'httponly'  => false,
+            'samesite' => 'Lax',
+        ) );
+        unset( $_COOKIE['cuft_utm_data'] );
     }
 }

--- a/includes/migrations/class-cuft-migration-3-22-0.php
+++ b/includes/migrations/class-cuft-migration-3-22-0.php
@@ -2,9 +2,11 @@
 /**
  * Migration for v3.22.0
  *
- * Adds ga_client_id and replayed_at columns to the click tracking table.
+ * Adds ga_client_id column to the click tracking table.
  * - ga_client_id: Stores the GA4 client ID from the _ga cookie for Measurement Protocol replay.
- * - replayed_at: Marks when webhook-driven events have been replayed to the client-side dataLayer.
+ *
+ * Replay tracking (replayed_at) is handled entirely within the JSON events blob,
+ * so no separate DB column is needed.
  *
  * @package Choice_UTM_Form_Tracker
  * @since 3.22.0
@@ -21,7 +23,7 @@ class CUFT_Migration_3_22_0 {
     /**
      * Execute schema migration (up)
      *
-     * Adds ga_client_id column after ip_hash and replayed_at column after events.
+     * Adds ga_client_id column after ip_hash.
      *
      * @return bool True on success, false on failure
      */
@@ -48,21 +50,10 @@ class CUFT_Migration_3_22_0 {
             }
         }
 
-        if ( ! in_array( 'replayed_at', $columns, true ) ) {
-            $result = $wpdb->query( "ALTER TABLE $table ADD COLUMN replayed_at datetime DEFAULT NULL AFTER events" );
-
-            if ( $result === false ) {
-                if ( class_exists( 'CUFT_Logger' ) ) {
-                    CUFT_Logger::log( 'error', 'Migration 3.22.0: Failed to add replayed_at column: ' . $wpdb->last_error );
-                }
-                return false;
-            }
-        }
-
         update_option( self::OPTION_KEY, true );
 
         if ( class_exists( 'CUFT_Logger' ) ) {
-            CUFT_Logger::log( 'info', 'Migration 3.22.0: Added ga_client_id and replayed_at columns' );
+            CUFT_Logger::log( 'info', 'Migration 3.22.0: Added ga_client_id column' );
         }
 
         return true;

--- a/includes/migrations/class-cuft-migration-3-22-0.php
+++ b/includes/migrations/class-cuft-migration-3-22-0.php
@@ -1,0 +1,79 @@
+<?php
+/**
+ * Migration for v3.22.0
+ *
+ * Adds ga_client_id and replayed_at columns to the click tracking table.
+ * - ga_client_id: Stores the GA4 client ID from the _ga cookie for Measurement Protocol replay.
+ * - replayed_at: Marks when webhook-driven events have been replayed to the client-side dataLayer.
+ *
+ * @package Choice_UTM_Form_Tracker
+ * @since 3.22.0
+ */
+
+if ( ! defined( 'ABSPATH' ) ) {
+    exit;
+}
+
+class CUFT_Migration_3_22_0 {
+
+    const OPTION_KEY = 'cuft_migration_3_22_0_completed';
+
+    /**
+     * Execute schema migration (up)
+     *
+     * Adds ga_client_id column after ip_hash and replayed_at column after events.
+     *
+     * @return bool True on success, false on failure
+     */
+    public static function up() {
+        global $wpdb;
+
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        // Check if migration already completed
+        if ( get_option( self::OPTION_KEY ) ) {
+            return true;
+        }
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+
+        if ( ! in_array( 'ga_client_id', $columns, true ) ) {
+            $result = $wpdb->query( "ALTER TABLE $table ADD COLUMN ga_client_id varchar(255) DEFAULT NULL AFTER ip_hash" );
+
+            if ( $result === false ) {
+                if ( class_exists( 'CUFT_Logger' ) ) {
+                    CUFT_Logger::log( 'error', 'Migration 3.22.0: Failed to add ga_client_id column: ' . $wpdb->last_error );
+                }
+                return false;
+            }
+        }
+
+        if ( ! in_array( 'replayed_at', $columns, true ) ) {
+            $result = $wpdb->query( "ALTER TABLE $table ADD COLUMN replayed_at datetime DEFAULT NULL AFTER events" );
+
+            if ( $result === false ) {
+                if ( class_exists( 'CUFT_Logger' ) ) {
+                    CUFT_Logger::log( 'error', 'Migration 3.22.0: Failed to add replayed_at column: ' . $wpdb->last_error );
+                }
+                return false;
+            }
+        }
+
+        update_option( self::OPTION_KEY, true );
+
+        if ( class_exists( 'CUFT_Logger' ) ) {
+            CUFT_Logger::log( 'info', 'Migration 3.22.0: Added ga_client_id and replayed_at columns' );
+        }
+
+        return true;
+    }
+
+    /**
+     * Check if migration needs to run
+     *
+     * @return bool True if migration is needed
+     */
+    public static function needs_migration() {
+        return ! get_option( self::OPTION_KEY, false );
+    }
+}

--- a/tests/standalone/lib/test-data.js
+++ b/tests/standalone/lib/test-data.js
@@ -189,8 +189,35 @@ window.CUFTTestData = (function() {
     gclid: "TeSter-123_abc"
   };
 
+  // Broad generate_lead: fires when email is present (GA4 convention)
   const expectedGenerateLeadEvent = {
     event: "generate_lead",
+    currency: "USD",
+    value: 0,
+    cuft_tracked: true,
+    cuft_source: "elementor_pro_lead",
+
+    // All form_submit fields also included
+    form_type: "elementor",
+    form_id: "contact-form-1",
+    form_name: "Contact Form",
+    user_email: "test@example.com",
+    submitted_at: "2025-01-01T12:00:00.000Z",
+
+    // GA4 parameters
+    page_location: "https://example.com/contact",
+    page_referrer: "https://google.com",
+    page_title: "Contact Us - Example Site",
+
+    // UTM parameters
+    utm_source: "google",
+    utm_medium: "cpc",
+    utm_campaign: "summer_sale_2025"
+  };
+
+  // Strict qualify_lead: fires when email + phone + click_id are all present
+  const expectedQualifyLeadEvent = {
+    event: "qualify_lead",
     currency: "USD",
     value: 0,
     cuft_tracked: true,
@@ -214,7 +241,7 @@ window.CUFTTestData = (function() {
     utm_medium: "cpc",
     utm_campaign: "summer_sale_2025",
 
-    // Click ID (at least one required)
+    // Click ID (at least one required for qualify_lead)
     gclid: "TeSter-123_abc"
   };
 
@@ -236,7 +263,7 @@ window.CUFTTestData = (function() {
       clickIds: {
         gclid: "test_click_id"
       },
-      expectedEvents: ["form_submit", "generate_lead"]
+      expectedEvents: ["form_submit", "generate_lead", "qualify_lead"]
     },
     {
       name: "Form with email only",
@@ -246,7 +273,7 @@ window.CUFTTestData = (function() {
       },
       utmParams: {},
       clickIds: {},
-      expectedEvents: ["form_submit"] // No generate_lead without click ID
+      expectedEvents: ["form_submit", "generate_lead"] // Broad generate_lead fires with just email
     },
     {
       name: "Form with phone only",
@@ -389,6 +416,7 @@ window.CUFTTestData = (function() {
     clickIdSets: clickIdSets,
     expectedFormSubmitEvent: expectedFormSubmitEvent,
     expectedGenerateLeadEvent: expectedGenerateLeadEvent,
+    expectedQualifyLeadEvent: expectedQualifyLeadEvent,
     positiveTestScenarios: positiveTestScenarios,
     negativeTestScenarios: negativeTestScenarios,
     performanceTestData: performanceTestData,

--- a/tests/standalone/test-dataLayer-core.html
+++ b/tests/standalone/test-dataLayer-core.html
@@ -157,38 +157,38 @@
 
             // Test Suite 6: Lead Qualification
             utils.describe('Lead Qualification Logic', function() {
-                utils.test('meetsLeadConditions() requires email, phone, and click ID', function() {
+                utils.test('meetsQualifyConditions() requires email, phone, and click ID', function() {
                     // All conditions met
                     const validPayload = {
                         user_email: 'test@example.com',
                         user_phone: '1234567890',
                         gclid: 'test_click_id'
                     };
-                    utils.assertEqual(dataLayerUtils.meetsLeadConditions(validPayload), true);
+                    utils.assertEqual(dataLayerUtils.meetsQualifyConditions(validPayload), true);
 
                     // Missing email
                     const noEmail = {
                         user_phone: '1234567890',
                         gclid: 'test_click_id'
                     };
-                    utils.assertEqual(dataLayerUtils.meetsLeadConditions(noEmail), false);
+                    utils.assertEqual(dataLayerUtils.meetsQualifyConditions(noEmail), false);
 
                     // Missing phone
                     const noPhone = {
                         user_email: 'test@example.com',
                         gclid: 'test_click_id'
                     };
-                    utils.assertEqual(dataLayerUtils.meetsLeadConditions(noPhone), false);
+                    utils.assertEqual(dataLayerUtils.meetsQualifyConditions(noPhone), false);
 
                     // Missing click ID
                     const noClickId = {
                         user_email: 'test@example.com',
                         user_phone: '1234567890'
                     };
-                    utils.assertEqual(dataLayerUtils.meetsLeadConditions(noClickId), false);
+                    utils.assertEqual(dataLayerUtils.meetsQualifyConditions(noClickId), false);
                 });
 
-                utils.test('meetsLeadConditions() accepts any valid click ID type', function() {
+                utils.test('meetsQualifyConditions() accepts any valid click ID type', function() {
                     const clickIdTypes = ['click_id', 'gclid', 'gbraid', 'wbraid', 'fbclid',
                                          'msclkid', 'ttclid', 'li_fat_id', 'twclid',
                                          'snap_click_id', 'pclid'];
@@ -200,11 +200,34 @@
                             [clickIdType]: 'test_id_123'
                         };
                         utils.assertEqual(
-                            dataLayerUtils.meetsLeadConditions(payload),
+                            dataLayerUtils.meetsQualifyConditions(payload),
                             true,
                             'Should accept ' + clickIdType
                         );
                     });
+                });
+
+                utils.test('meetsGenerateLeadConditions() requires only email', function() {
+                    // Email present
+                    utils.assertEqual(
+                        dataLayerUtils.meetsGenerateLeadConditions({ user_email: 'test@example.com' }),
+                        true,
+                        'Should return true when email is present'
+                    );
+
+                    // No email
+                    utils.assertEqual(
+                        dataLayerUtils.meetsGenerateLeadConditions({ user_phone: '1234567890' }),
+                        false,
+                        'Should return false when email is missing'
+                    );
+
+                    // Empty payload
+                    utils.assertEqual(
+                        dataLayerUtils.meetsGenerateLeadConditions({}),
+                        false,
+                        'Should return false for empty payload'
+                    );
                 });
             });
 
@@ -260,9 +283,33 @@
                 });
             });
 
-            // Test Suite 8: Generate Lead Event Creation
-            utils.describe('Generate Lead Event Creation', function() {
-                utils.test('createGenerateLeadPayload() includes all required fields', function() {
+            // Test Suite 8: Lead Event Creation
+            utils.describe('Lead Event Creation', function() {
+                utils.test('createGenerateLeadPayload() creates broad generate_lead event', function() {
+                    const formSubmitPayload = {
+                        event: 'form_submit',
+                        form_type: 'elementor',
+                        form_id: 'test-form',
+                        user_email: 'test@example.com',
+                        submitted_at: '2025-01-01T12:00:00.000Z',
+                        cuft_tracked: true,
+                        cuft_source: 'elementor_pro'
+                    };
+
+                    const leadPayload = dataLayerUtils.createGenerateLeadPayload(formSubmitPayload, 'elementor');
+
+                    utils.assertEqual(leadPayload.event, 'generate_lead', 'Event must be generate_lead');
+                    utils.assertEqual(leadPayload.cuft_source, 'elementor_pro_lead', 'Should use lead-specific source');
+                    utils.assertEqual(leadPayload.currency, 'CAD', 'Default currency must be CAD');
+                    utils.assertEqual(leadPayload.value, 100, 'Default value must be 100');
+
+                    // All form fields should be included
+                    utils.assertEqual(leadPayload.form_type, 'elementor');
+                    utils.assertEqual(leadPayload.form_id, 'test-form');
+                    utils.assertEqual(leadPayload.user_email, 'test@example.com');
+                });
+
+                utils.test('createQualifyLeadPayload() creates strict qualify_lead event', function() {
                     const formSubmitPayload = {
                         event: 'form_submit',
                         form_type: 'elementor',
@@ -275,19 +322,19 @@
                         gclid: 'test_click_id'
                     };
 
-                    const leadPayload = dataLayerUtils.createGenerateLeadPayload(formSubmitPayload, 'elementor');
+                    const qualifyPayload = dataLayerUtils.createQualifyLeadPayload(formSubmitPayload, 'elementor');
 
-                    utils.assertEqual(leadPayload.event, 'generate_lead', 'Event must be generate_lead');
-                    utils.assertEqual(leadPayload.cuft_source, 'elementor_pro_lead', 'Should use lead-specific source');
-                    utils.assertEqual(leadPayload.currency, 'USD', 'Currency must be USD');
-                    utils.assertEqual(leadPayload.value, 0, 'Value must be 0');
+                    utils.assertEqual(qualifyPayload.event, 'qualify_lead', 'Event must be qualify_lead');
+                    utils.assertEqual(qualifyPayload.cuft_source, 'elementor_pro_lead', 'Should use lead-specific source');
+                    utils.assertEqual(qualifyPayload.currency, 'CAD', 'Default currency must be CAD');
+                    utils.assertEqual(qualifyPayload.value, 100, 'Default value must be 100');
 
                     // All form fields should be included
-                    utils.assertEqual(leadPayload.form_type, 'elementor');
-                    utils.assertEqual(leadPayload.form_id, 'test-form');
-                    utils.assertEqual(leadPayload.user_email, 'test@example.com');
-                    utils.assertEqual(leadPayload.user_phone, '1234567890');
-                    utils.assertEqual(leadPayload.gclid, 'test_click_id');
+                    utils.assertEqual(qualifyPayload.form_type, 'elementor');
+                    utils.assertEqual(qualifyPayload.form_id, 'test-form');
+                    utils.assertEqual(qualifyPayload.user_email, 'test@example.com');
+                    utils.assertEqual(qualifyPayload.user_phone, '1234567890');
+                    utils.assertEqual(qualifyPayload.gclid, 'test_click_id');
                 });
 
                 utils.test('Lead source naming follows specification pattern', function() {
@@ -310,7 +357,7 @@
 
             // Test Suite 9: Full Tracking Flow
             utils.describe('Complete Form Tracking Flow', function() {
-                utils.test('trackFormSubmission() fires form_submit event with correct data', function() {
+                utils.test('trackFormSubmission() fires form_submit and generate_lead with email', function() {
                     const form = utils.createFormFromTemplate(testData.formTemplates.elementor);
                     const mockDL = utils.setupMockDataLayer();
 
@@ -322,19 +369,23 @@
                     });
 
                     utils.assertEqual(result, true, 'Tracking should succeed');
-                    utils.assertEqual(mockDL.events.length, 1, 'Should fire exactly one event');
+                    utils.assertEqual(mockDL.events.length, 2, 'Should fire two events (form_submit and generate_lead)');
 
-                    const event = mockDL.getLastEvent();
-                    utils.assertEqual(event.event, 'form_submit');
-                    utils.assertEqual(event.cuft_tracked, true);
-                    utils.assertEqual(event.form_id, 'contact-form-1');
-                    utils.assertEqual(event.user_phone, '5551234567', 'Phone should be sanitized');
+                    const formEvent = mockDL.events[0];
+                    utils.assertEqual(formEvent.event, 'form_submit');
+                    utils.assertEqual(formEvent.cuft_tracked, true);
+                    utils.assertEqual(formEvent.form_id, 'contact-form-1');
+                    utils.assertEqual(formEvent.user_phone, '5551234567', 'Phone should be sanitized');
+
+                    const generateEvent = mockDL.events[1];
+                    utils.assertEqual(generateEvent.event, 'generate_lead', 'Broad generate_lead should fire with email');
+                    utils.assertEqual(generateEvent.cuft_source, 'elementor_pro_lead');
 
                     mockDL.restore();
                     utils.cleanupTestContainer(form.parentElement);
                 });
 
-                utils.test('trackFormSubmission() fires generate_lead when conditions are met', function() {
+                utils.test('trackFormSubmission() fires generate_lead, qualify_lead, and deprecated generate_lead when all conditions met', function() {
                     const form = utils.createFormFromTemplate(testData.formTemplates.elementor);
                     const mockDL = utils.setupMockDataLayer();
 
@@ -350,16 +401,27 @@
                     });
 
                     utils.assertEqual(result, true, 'Tracking should succeed');
-                    utils.assertEqual(mockDL.events.length, 2, 'Should fire two events (form_submit and generate_lead)');
+                    utils.assertEqual(mockDL.events.length, 4, 'Should fire four events (form_submit, generate_lead, qualify_lead, deprecated generate_lead)');
 
                     const formEvent = mockDL.events[0];
-                    const leadEvent = mockDL.events[1];
+                    const generateLeadEvent = mockDL.events[1];
+                    const qualifyLeadEvent = mockDL.events[2];
+                    const deprecatedEvent = mockDL.events[3];
 
                     utils.assertEqual(formEvent.event, 'form_submit');
-                    utils.assertEqual(leadEvent.event, 'generate_lead');
-                    utils.assertEqual(leadEvent.currency, 'USD');
-                    utils.assertEqual(leadEvent.value, 0);
-                    utils.assertEqual(leadEvent.cuft_source, 'elementor_pro_lead');
+
+                    // Broad generate_lead (fires because email present)
+                    utils.assertEqual(generateLeadEvent.event, 'generate_lead');
+                    utils.assertEqual(generateLeadEvent.cuft_source, 'elementor_pro_lead');
+
+                    // Strict qualify_lead (fires because email + phone + click_id)
+                    utils.assertEqual(qualifyLeadEvent.event, 'qualify_lead');
+                    utils.assertEqual(qualifyLeadEvent.cuft_source, 'elementor_pro_lead');
+
+                    // Deprecated dual-fire generate_lead with strict payload
+                    utils.assertEqual(deprecatedEvent.event, 'generate_lead');
+                    utils.assertEqual(deprecatedEvent.cuft_deprecated, true);
+                    utils.assertEqual(deprecatedEvent.cuft_migrate_to, 'qualify_lead');
 
                     // Cleanup
                     delete window.cuftGetTrackingData;

--- a/tests/unit/test-admin-secrets.php
+++ b/tests/unit/test-admin-secrets.php
@@ -1,0 +1,26 @@
+<?php
+/**
+ * Tests for admin API credentials settings and Token Manager DB fallback.
+ */
+
+class Test_Admin_Secrets extends WP_UnitTestCase {
+
+    public function test_register_secret_falls_back_to_option() {
+        update_option( 'cuft_register_secret', 'test-secret-from-db' );
+        $secret = CUFT_Token_Manager::get_register_secret_value();
+        $this->assertEquals( 'test-secret-from-db', $secret );
+        delete_option( 'cuft_register_secret' );
+    }
+
+    public function test_measurement_id_option() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        $this->assertEquals( 'G-TEST123', get_option( 'cuft_measurement_id', '' ) );
+        delete_option( 'cuft_measurement_id' );
+    }
+
+    public function test_measurement_api_secret_option() {
+        update_option( 'cuft_measurement_api_secret', 'secret123' );
+        $this->assertEquals( 'secret123', get_option( 'cuft_measurement_api_secret', '' ) );
+        delete_option( 'cuft_measurement_api_secret' );
+    }
+}

--- a/tests/unit/test-event-constants.php
+++ b/tests/unit/test-event-constants.php
@@ -1,0 +1,63 @@
+<?php
+/**
+ * Unit Tests for Event Constants and Display Helpers
+ *
+ * Tests valid event type lists, display names, and icons
+ * for GA4 lifecycle event types.
+ *
+ * @package Choice_Universal_Form_Tracker
+ * @since 3.22.0
+ */
+
+class Test_Event_Constants extends WP_UnitTestCase {
+
+    public function test_event_recorder_includes_qualify_lead() {
+        $valid = CUFT_Event_Recorder::VALID_EVENT_TYPES;
+        $this->assertContains( 'qualify_lead', $valid );
+    }
+
+    public function test_event_recorder_includes_generate_lead() {
+        $valid = CUFT_Event_Recorder::VALID_EVENT_TYPES;
+        $this->assertContains( 'generate_lead', $valid );
+    }
+
+    public function test_utils_display_name_for_qualify_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'qualify_lead' );
+        $this->assertEquals( 'Qualify Lead', $name );
+    }
+
+    public function test_utils_display_name_for_disqualify_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'disqualify_lead' );
+        $this->assertEquals( 'Disqualify Lead', $name );
+    }
+
+    public function test_utils_display_name_for_working_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'working_lead' );
+        $this->assertEquals( 'Working Lead', $name );
+    }
+
+    public function test_utils_display_name_for_close_convert_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'close_convert_lead' );
+        $this->assertEquals( 'Close Convert Lead', $name );
+    }
+
+    public function test_utils_display_name_for_close_unconvert_lead() {
+        $name = CUFT_Utils::get_event_display_name( 'close_unconvert_lead' );
+        $this->assertEquals( 'Close Unconvert Lead', $name );
+    }
+
+    public function test_utils_icon_for_qualify_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'qualify_lead' );
+        $this->assertEquals( '⭐', $icon );
+    }
+
+    public function test_utils_icon_for_working_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'working_lead' );
+        $this->assertEquals( '📋', $icon );
+    }
+
+    public function test_utils_icon_for_close_convert_lead() {
+        $icon = CUFT_Utils::get_event_icon( 'close_convert_lead' );
+        $this->assertEquals( '✅', $icon );
+    }
+}

--- a/tests/unit/test-event-replay.php
+++ b/tests/unit/test-event-replay.php
@@ -1,0 +1,129 @@
+<?php
+/**
+ * Unit Tests for CUFT_Event_Replay
+ *
+ * Verifies that unreplayed webhook events are returned correctly
+ * and that marking them as replayed prevents duplicate replay.
+ *
+ * @package Choice_Universal_Form_Tracker
+ * @since   3.22.0
+ */
+
+class Test_Event_Replay extends WP_UnitTestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        parent::set_up_before_class();
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        parent::set_up();
+        global $wpdb;
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-replay-click',
+            'platform'     => 'google',
+            'qualified'    => 1,
+            'score'        => 0,
+            'ga_client_id' => '111.222',
+            'events'       => wp_json_encode( array(
+                array(
+                    'event'     => 'form_submit',
+                    'timestamp' => '2026-04-01T10:00:00+00:00',
+                ),
+                array(
+                    'event'       => 'qualify_lead',
+                    'timestamp'   => '2026-04-02T14:00:00+00:00',
+                    'source'      => 'webhook',
+                    'replayed_at' => null,
+                ),
+            ) ),
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-replay-click' ) );
+        parent::tear_down();
+    }
+
+    public function test_get_pending_events_returns_unreplayed_webhook_events() {
+        $pending = CUFT_Event_Replay::get_pending_events( 'test-replay-click' );
+        $this->assertCount( 1, $pending );
+        $this->assertEquals( 'qualify_lead', $pending[0]['event'] );
+        $this->assertEquals( 'webhook', $pending[0]['source'] );
+    }
+
+    public function test_get_pending_events_excludes_non_webhook_events() {
+        $pending = CUFT_Event_Replay::get_pending_events( 'test-replay-click' );
+        foreach ( $pending as $event ) {
+            $this->assertEquals( 'webhook', $event['source'] );
+        }
+    }
+
+    public function test_get_pending_events_returns_empty_for_unknown_click_id() {
+        $pending = CUFT_Event_Replay::get_pending_events( 'nonexistent-click-id' );
+        $this->assertCount( 0, $pending );
+    }
+
+    public function test_mark_events_replayed_sets_timestamp() {
+        CUFT_Event_Replay::mark_events_replayed( 'test-replay-click' );
+        $pending = CUFT_Event_Replay::get_pending_events( 'test-replay-click' );
+        $this->assertCount( 0, $pending );
+    }
+
+    public function test_mark_events_replayed_preserves_non_webhook_events() {
+        CUFT_Event_Replay::mark_events_replayed( 'test-replay-click' );
+
+        global $wpdb;
+        $table = self::$table_name;
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM $table WHERE click_id = %s",
+            'test-replay-click'
+        ) );
+
+        $events = json_decode( $row->events, true );
+        $this->assertCount( 2, $events );
+        // form_submit should be untouched (no source, no replayed_at)
+        $this->assertEquals( 'form_submit', $events[0]['event'] );
+        $this->assertArrayNotHasKey( 'source', $events[0] );
+    }
+
+    public function test_add_event_with_webhook_source_includes_replay_fields() {
+        CUFT_Click_Tracker::add_event( 'test-replay-click', 'working_lead', 'webhook' );
+
+        $events = CUFT_Click_Tracker::get_events( 'test-replay-click' );
+        $working = null;
+        foreach ( $events as $event ) {
+            if ( 'working_lead' === $event['event'] ) {
+                $working = $event;
+                break;
+            }
+        }
+
+        $this->assertNotNull( $working, 'working_lead event should exist' );
+        $this->assertEquals( 'webhook', $working['source'] );
+        $this->assertArrayHasKey( 'replayed_at', $working );
+        $this->assertNull( $working['replayed_at'] );
+    }
+
+    public function test_add_event_without_source_has_no_replay_fields() {
+        CUFT_Click_Tracker::add_event( 'test-replay-click', 'phone_click' );
+
+        $events = CUFT_Click_Tracker::get_events( 'test-replay-click' );
+        $phone = null;
+        foreach ( $events as $event ) {
+            if ( 'phone_click' === $event['event'] ) {
+                $phone = $event;
+                break;
+            }
+        }
+
+        $this->assertNotNull( $phone, 'phone_click event should exist' );
+        $this->assertArrayNotHasKey( 'source', $phone );
+        $this->assertArrayNotHasKey( 'replayed_at', $phone );
+    }
+}

--- a/tests/unit/test-measurement-protocol.php
+++ b/tests/unit/test-measurement-protocol.php
@@ -1,0 +1,53 @@
+<?php
+// tests/unit/test-measurement-protocol.php
+
+class Test_Measurement_Protocol extends WP_UnitTestCase {
+
+    public function test_build_payload_structure() {
+        $mp = new CUFT_Measurement_Protocol();
+        $payload = $mp->build_payload( '123456.789012', 'qualify_lead', array(
+            'click_id'    => 'abc123',
+            'lead_source' => 'gravity_forms',
+        ) );
+
+        $this->assertEquals( '123456.789012', $payload['client_id'] );
+        $this->assertCount( 1, $payload['events'] );
+        $this->assertEquals( 'qualify_lead', $payload['events'][0]['name'] );
+        $this->assertEquals( 'abc123', $payload['events'][0]['params']['click_id'] );
+        $this->assertEquals( 'gravity_forms', $payload['events'][0]['params']['lead_source'] );
+        $this->assertEquals( 1, $payload['events'][0]['params']['engagement_time_msec'] );
+    }
+
+    public function test_build_payload_includes_lead_value() {
+        update_option( 'cuft_lead_value', 250 );
+        update_option( 'cuft_lead_currency', 'USD' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $payload = $mp->build_payload( '123.456', 'close_convert_lead', array() );
+
+        $this->assertEquals( 250, $payload['events'][0]['params']['value'] );
+        $this->assertEquals( 'USD', $payload['events'][0]['params']['currency'] );
+
+        delete_option( 'cuft_lead_value' );
+        delete_option( 'cuft_lead_currency' );
+    }
+
+    public function test_is_configured_returns_false_when_missing() {
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $this->assertFalse( $mp->is_configured() );
+    }
+
+    public function test_is_configured_returns_true_when_set() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        update_option( 'cuft_measurement_api_secret', 'secret' );
+
+        $mp = new CUFT_Measurement_Protocol();
+        $this->assertTrue( $mp->is_configured() );
+
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+    }
+}

--- a/tests/unit/test-migration-3-22-0.php
+++ b/tests/unit/test-migration-3-22-0.php
@@ -2,8 +2,8 @@
 /**
  * Unit Tests for Migration 3.22.0
  *
- * Tests that the migration correctly adds ga_client_id and replayed_at
- * columns to the cuft_click_tracking table.
+ * Tests that the migration correctly adds ga_client_id column
+ * to the cuft_click_tracking table.
  *
  * @package Choice_UTM_Form_Tracker
  * @since 3.22.0
@@ -25,16 +25,6 @@ class Test_Migration_3_22_0 extends WP_UnitTestCase {
 
         $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
         $this->assertContains( 'ga_client_id', $columns );
-    }
-
-    public function test_migration_adds_replayed_at_column() {
-        global $wpdb;
-        $table = $wpdb->prefix . 'cuft_click_tracking';
-
-        CUFT_Migration_3_22_0::up();
-
-        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
-        $this->assertContains( 'replayed_at', $columns );
     }
 
     public function test_needs_migration_returns_true_before_running() {

--- a/tests/unit/test-migration-3-22-0.php
+++ b/tests/unit/test-migration-3-22-0.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Unit Tests for Migration 3.22.0
+ *
+ * Tests that the migration correctly adds ga_client_id and replayed_at
+ * columns to the cuft_click_tracking table.
+ *
+ * @package Choice_UTM_Form_Tracker
+ * @since 3.22.0
+ */
+
+class Test_Migration_3_22_0 extends WP_UnitTestCase {
+
+    public function setUp(): void {
+        parent::setUp();
+        // Reset migration state before each test
+        delete_option( CUFT_Migration_3_22_0::OPTION_KEY );
+    }
+
+    public function test_migration_adds_ga_client_id_column() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        CUFT_Migration_3_22_0::up();
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+        $this->assertContains( 'ga_client_id', $columns );
+    }
+
+    public function test_migration_adds_replayed_at_column() {
+        global $wpdb;
+        $table = $wpdb->prefix . 'cuft_click_tracking';
+
+        CUFT_Migration_3_22_0::up();
+
+        $columns = $wpdb->get_col( "SHOW COLUMNS FROM $table" );
+        $this->assertContains( 'replayed_at', $columns );
+    }
+
+    public function test_needs_migration_returns_true_before_running() {
+        delete_option( CUFT_Migration_3_22_0::OPTION_KEY );
+        $this->assertTrue( CUFT_Migration_3_22_0::needs_migration() );
+    }
+
+    public function test_needs_migration_returns_false_after_running() {
+        CUFT_Migration_3_22_0::up();
+        $this->assertFalse( CUFT_Migration_3_22_0::needs_migration() );
+    }
+
+    public function test_migration_is_idempotent() {
+        // Running up() twice should not error
+        $first = CUFT_Migration_3_22_0::up();
+        $second = CUFT_Migration_3_22_0::up();
+
+        $this->assertTrue( $first );
+        $this->assertTrue( $second );
+    }
+}

--- a/tests/unit/test-webhook-mp-integration.php
+++ b/tests/unit/test-webhook-mp-integration.php
@@ -1,0 +1,64 @@
+<?php
+// tests/unit/test-webhook-mp-integration.php
+
+class Test_Webhook_MP_Integration extends WP_UnitTestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        parent::set_up_before_class();
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        parent::set_up();
+        global $wpdb;
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-mp-click',
+            'platform'     => 'google',
+            'qualified'    => 0,
+            'score'        => 0,
+            'ga_client_id' => '111111.222222',
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-mp-click' ) );
+        delete_option( 'cuft_measurement_id' );
+        delete_option( 'cuft_measurement_api_secret' );
+        parent::tear_down();
+    }
+
+    public function test_webhook_status_records_event_when_mp_configured() {
+        update_option( 'cuft_measurement_id', 'G-TEST123' );
+        update_option( 'cuft_measurement_api_secret', 'secret' );
+
+        CUFT_Click_Tracker::update_click_status( 'test-mp-click', null, null, 'qualify_lead' );
+
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-mp-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'qualify_lead', $last_event['event'] );
+    }
+
+    public function test_webhook_records_event_when_mp_not_configured() {
+        // No measurement options set — event should still be recorded
+        CUFT_Click_Tracker::update_click_status( 'test-mp-click', null, null, 'working_lead' );
+
+        global $wpdb;
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-mp-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'working_lead', $last_event['event'] );
+    }
+}

--- a/tests/unit/test-webhook-status.php
+++ b/tests/unit/test-webhook-status.php
@@ -1,0 +1,67 @@
+<?php
+// tests/unit/test-webhook-status.php
+
+class Test_Webhook_Status extends WP_UnitTestCase {
+
+    private static $table_name;
+
+    public static function set_up_before_class() {
+        parent::set_up_before_class();
+        global $wpdb;
+        self::$table_name = $wpdb->prefix . 'cuft_click_tracking';
+        CUFT_Click_Tracker::create_table();
+    }
+
+    public function set_up() {
+        parent::set_up();
+        global $wpdb;
+        $wpdb->insert( self::$table_name, array(
+            'click_id'     => 'test-webhook-click',
+            'platform'     => 'google',
+            'qualified'    => 0,
+            'score'        => 0,
+            'ga_client_id' => '123456.789012',
+        ) );
+    }
+
+    public function tear_down() {
+        global $wpdb;
+        $wpdb->delete( self::$table_name, array( 'click_id' => 'test-webhook-click' ) );
+        parent::tear_down();
+    }
+
+    public function test_valid_status_values() {
+        $valid = CUFT_Click_Tracker::get_valid_webhook_statuses();
+        $this->assertContains( 'qualify_lead', $valid );
+        $this->assertContains( 'disqualify_lead', $valid );
+        $this->assertContains( 'working_lead', $valid );
+        $this->assertContains( 'close_convert_lead', $valid );
+        $this->assertContains( 'close_unconvert_lead', $valid );
+    }
+
+    public function test_status_parameter_records_event() {
+        global $wpdb;
+        CUFT_Click_Tracker::update_click_status( 'test-webhook-click', null, null, 'working_lead' );
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-webhook-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'working_lead', $last_event['event_type'] );
+    }
+
+    public function test_qualified_param_maps_to_qualify_lead() {
+        global $wpdb;
+        CUFT_Click_Tracker::update_click_status( 'test-webhook-click', 1 );
+
+        $row = $wpdb->get_row( $wpdb->prepare(
+            "SELECT events FROM " . self::$table_name . " WHERE click_id = %s",
+            'test-webhook-click'
+        ) );
+        $events = json_decode( $row->events, true );
+        $last_event = end( $events );
+        $this->assertEquals( 'qualify_lead', $last_event['event_type'] );
+    }
+}

--- a/tests/unit/test-webhook-status.php
+++ b/tests/unit/test-webhook-status.php
@@ -49,7 +49,7 @@ class Test_Webhook_Status extends WP_UnitTestCase {
         ) );
         $events = json_decode( $row->events, true );
         $last_event = end( $events );
-        $this->assertEquals( 'working_lead', $last_event['event_type'] );
+        $this->assertEquals( 'working_lead', $last_event['event'] );
     }
 
     public function test_qualified_param_maps_to_qualify_lead() {
@@ -62,6 +62,6 @@ class Test_Webhook_Status extends WP_UnitTestCase {
         ) );
         $events = json_decode( $row->events, true );
         $last_event = end( $events );
-        $this->assertEquals( 'qualify_lead', $last_event['event_type'] );
+        $this->assertEquals( 'qualify_lead', $last_event['event'] );
     }
 }


### PR DESCRIPTION
## Summary

- **GA4 event naming alignment** — `generate_lead` now fires on any form with a valid email (GA4 convention). The previous strict behavior (email+phone+click_id) is renamed to `qualify_lead`. A dual-fire deprecation strategy fires both during the transition.
- **Full lead lifecycle via webhook** — New `status` parameter accepts `qualify_lead`, `disqualify_lead`, `working_lead`, `close_convert_lead`, `close_unconvert_lead`. Backward compatible: `qualified=1` still works.
- **GA4 Measurement Protocol** — Server-side events fire at webhook time via the MP API. Configurable from wp-admin (Measurement ID + API Secret).
- **Client-side event replay** — Webhook-driven events are queued and pushed to `dataLayer` on the lead's next pageview, enabling GTM to fire client-side tags for server-side status changes.
- **Admin settings for secrets** — Registration secret, GA4 Measurement ID, and API Secret configurable from Settings. Encrypted with AES-256-CBC using AUTH_SALT. wp-config.php constants still override.

## Changes

- 24 files changed, +1523 / -121
- 7 new test files (33 tests, 53 assertions — all passing)
- 1 new DB migration (adds `ga_client_id` column)
- 3 new classes: `CUFT_Measurement_Protocol`, `CUFT_Event_Replay`, `CUFT_Migration_3_22_0`

## Security

- Replay AJAX endpoint requires nonce verification
- Atomic `SELECT ... FOR UPDATE` transaction prevents race conditions in event replay
- Secrets encrypted at rest with AES-256-CBC, never rendered in HTML
- Backward-compatible decryption handles pre-existing plaintext values

## Test plan

- [x] All 33 new PHPUnit tests pass (admin secrets, event constants, event replay, measurement protocol, migration, webhook status, webhook MP integration)
- [x] Pre-existing test failures unchanged from master (not caused by this PR)
- [x] PHP lint passes on all 24 changed files
- [x] JS syntax check passes on all changed JS files
- [x] Webhook `status` parameter tested with all 5 lifecycle values — returns correct JSON, stores events with `source: "webhook"`
- [x] Webhook backward compat verified — `qualified=1` still maps to `qualify_lead`
- [x] Invalid status returns 400 with guidance
- [x] Replay endpoint rejects requests without nonce (403)
- [x] Replay endpoint returns pending events, marks as replayed atomically
- [x] Second replay call returns empty (once-only replay confirmed)
- [x] Secret encryption roundtrip verified (encrypt → decrypt → matches)
- [x] Plaintext backward compat verified (decrypt on unencrypted value passes through)
- [x] DB migration applied — `ga_client_id` column present
- [ ] Manual browser test: submit form, verify `form_submit` + `generate_lead` + `qualify_lead` dataLayer events
- [ ] Manual browser test: verify `cuft_deprecated: true` on legacy `generate_lead` when strict criteria met
- [ ] Test on staging site before deploying to production